### PR TITLE
Bugfix

### DIFF
--- a/cloudproxy/check.py
+++ b/cloudproxy/check.py
@@ -37,14 +37,15 @@ def fetch_ip(ip_address):
     s.proxies = proxies
 
     fetched_ip = requests_retry_session(session=s).get(
-        "https://api.ipify.org", proxies=proxies
+        "https://api.ipify.org", proxies=proxies, timeout=10
     )
     return fetched_ip.text
 
 
 def check_alive(ip_address):
     try:
-        if ip_address == fetch_ip(ip_address):
+        result = requests.get("http://" + ip_address + ":8899", timeout=3)
+        if result.status_code in (200, 407):
             return True
         else:
             return False

--- a/cloudproxy/check.py
+++ b/cloudproxy/check.py
@@ -5,7 +5,7 @@ from cloudproxy.providers import settings
 
 
 def requests_retry_session(
-    retries=3,
+    retries=1,
     backoff_factor=0.3,
     status_forcelist=(500, 502, 504),
     session=None,

--- a/cloudproxy/main.py
+++ b/cloudproxy/main.py
@@ -44,26 +44,28 @@ def get_ip_list():
     ip_list = []
     if settings.config["providers"]["digitalocean"]["ips"]:
         for ip in settings.config["providers"]["digitalocean"]["ips"]:
-            ip_list.append(
-                "http://"
-                + settings.config["auth"]["username"]
-                + ":"
-                + settings.config["auth"]["password"]
-                + "@"
-                + ip
-                + ":8899"
-            )
+            if ip not in delete_queue:
+                ip_list.append(
+                    "http://"
+                    + settings.config["auth"]["username"]
+                    + ":"
+                    + settings.config["auth"]["password"]
+                    + "@"
+                    + ip
+                    + ":8899"
+                )
     if settings.config["providers"]["aws"]["ips"]:
         for ip in settings.config["providers"]["aws"]["ips"]:
-            ip_list.append(
-                "http://"
-                + settings.config["auth"]["username"]
-                + ":"
-                + settings.config["auth"]["password"]
-                + "@"
-                + ip
-                + ":8899"
-            )
+            if ip not in delete_queue:
+                ip_list.append(
+                    "http://"
+                    + settings.config["auth"]["username"]
+                    + ":"
+                    + settings.config["auth"]["password"]
+                    + "@"
+                    + ip
+                    + ":8899"
+                )
     return ip_list
 
 
@@ -97,7 +99,7 @@ def remove_proxy(ip_address: str):
     if re.findall(r"[0-9]+(?:\.[0-9]+){3}", ip_address):
         ip = re.findall(r"[0-9]+(?:\.[0-9]+){3}", ip_address)
         delete_queue.add(ip[0])
-        return {"Proxy to be destroyed"}
+        return {"Proxy <{}> to be destroyed".format(ip[0])}
     else:
         raise HTTPException(status_code=422, detail="IP not found")
 

--- a/cloudproxy/main.py
+++ b/cloudproxy/main.py
@@ -12,7 +12,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from uvicorn_loguru_integration import run_uvicorn_loguru
 from cloudproxy.providers import settings
-from cloudproxy.providers.settings import delete_queue
+from cloudproxy.providers.settings import delete_queue, restart_queue
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
@@ -44,7 +44,7 @@ def get_ip_list():
     ip_list = []
     if settings.config["providers"]["digitalocean"]["ips"]:
         for ip in settings.config["providers"]["digitalocean"]["ips"]:
-            if ip not in delete_queue:
+            if ip not in delete_queue and ip not in restart_queue:
                 ip_list.append(
                     "http://"
                     + settings.config["auth"]["username"]
@@ -56,7 +56,7 @@ def get_ip_list():
                 )
     if settings.config["providers"]["aws"]["ips"]:
         for ip in settings.config["providers"]["aws"]["ips"]:
-            if ip not in delete_queue:
+            if ip not in delete_queue and ip not in restart_queue:
                 ip_list.append(
                     "http://"
                     + settings.config["auth"]["username"]
@@ -100,6 +100,22 @@ def remove_proxy(ip_address: str):
         ip = re.findall(r"[0-9]+(?:\.[0-9]+){3}", ip_address)
         delete_queue.add(ip[0])
         return {"Proxy <{}> to be destroyed".format(ip[0])}
+    else:
+        raise HTTPException(status_code=422, detail="IP not found")
+
+
+@app.get("/restart")
+def restart_proxy_list():
+    response = set_default(restart_queue)
+    return JSONResponse(response)
+
+
+@app.delete("/restart")
+def restart_proxy(ip_address: str):
+    if re.findall(r"[0-9]+(?:\.[0-9]+){3}", ip_address):
+        ip = re.findall(r"[0-9]+(?:\.[0-9]+){3}", ip_address)
+        restart_queue.add(ip[0])
+        return {"Proxy <{}> to be restarted".format(ip[0])}
     else:
         raise HTTPException(status_code=422, detail="IP not found")
 

--- a/cloudproxy/providers/aws/functions.py
+++ b/cloudproxy/providers/aws/functions.py
@@ -36,6 +36,9 @@ def create_proxy():
         sg.authorize_ingress(
             CidrIp="0.0.0.0/0", IpProtocol="tcp", FromPort=8899, ToPort=8899
         )
+        sg.authorize_ingress(
+            CidrIp="0.0.0.0/0", IpProtocol="tcp", FromPort=22, ToPort=22
+        )
     except botocore.exceptions.ClientError:
         pass
     sg_id = ec2_client.describe_security_groups(GroupNames=["cloudproxy"])
@@ -60,10 +63,22 @@ def delete_proxy(instance_id):
     return deleted
 
 
+def stop_proxy(instance_id):
+    ids = [instance_id]
+    stopped = ec2.instances.filter(InstanceIds=ids).stop()
+    return stopped
+
+
+def start_proxy(instance_id):
+    ids = [instance_id]
+    started = ec2.instances.filter(InstanceIds=ids).start()
+    return started
+
+
 def list_instances():
     filters = [
         {"Name": "tag:cloudproxy", "Values": ["cloudproxy"]},
-        {"Name": "instance-state-name", "Values": ["pending", "running"]},
+        {"Name": "instance-state-name", "Values": ["pending", "running", "stopped", "stopping"]},
     ]
     instances = ec2_client.describe_instances(Filters=filters)
     return instances["Reservations"]

--- a/cloudproxy/providers/aws/main.py
+++ b/cloudproxy/providers/aws/main.py
@@ -8,8 +8,10 @@ from cloudproxy.providers.aws.functions import (
     list_instances,
     create_proxy,
     delete_proxy,
+    stop_proxy,
+    start_proxy,
 )
-from cloudproxy.providers.settings import delete_queue, config
+from cloudproxy.providers.settings import delete_queue, restart_queue, config
 
 
 def aws_deployment(min_scaling):
@@ -50,6 +52,20 @@ def aws_check_alive():
                     logger.info(
                         "Recycling droplet, reached age limit -> " + instance["Instances"][0]["PublicIpAddress"]
                     )
+            elif instance["Instances"][0]["State"]["Name"] == "stopped":
+                logger.info(
+                    "Waking up: AWS -> Instance " + instance["Instances"][0]["InstanceId"]
+                )
+                start_proxy(instance["Instances"][0]["InstanceId"])
+            elif instance["Instances"][0]["State"]["Name"] == "stopping":
+                logger.info(
+                    "Stopping: AWS -> " + instance["Instances"][0]["PublicIpAddress"]
+                )
+            elif instance["Instances"][0]["State"]["Name"] == "pending":
+                logger.info(
+                    "Pending: AWS -> " + instance["Instances"][0]["PublicIpAddress"]
+                )
+            # Must be "pending" if none of the above, check if alive or not.
             elif check_alive(instance["Instances"][0]["PublicIpAddress"]):
                 logger.info(
                     "Alive: AWS -> " + instance["Instances"][0]["PublicIpAddress"]
@@ -67,7 +83,7 @@ def aws_check_alive():
                         "Waiting: AWS -> " + instance["Instances"][0]["PublicIpAddress"]
                     )
         except (TypeError, KeyError):
-            logger.info("Pending: AWS allocating")
+            logger.info("Pending: AWS -> allocating ip")
     return ip_ready
 
 
@@ -82,8 +98,20 @@ def aws_check_delete():
             delete_queue.remove(instance["Instances"][0]["PublicIpAddress"])
 
 
+def aws_check_stop():
+    for instance in list_instances():
+        if instance["Instances"][0].get("PublicIpAddress") in restart_queue:
+            stop_proxy(instance["Instances"][0]["InstanceId"])
+            logger.info(
+                "Stopped: getting new IP -> "
+                + instance["Instances"][0]["PublicIpAddress"]
+            )
+            restart_queue.remove(instance["Instances"][0]["PublicIpAddress"])
+
+
 def aws_start():
     aws_check_delete()
+    aws_check_stop()
     aws_deployment(config["providers"]["aws"]["scaling"]["min_scaling"])
     ip_ready = aws_check_alive()
     return ip_ready

--- a/cloudproxy/providers/aws/main.py
+++ b/cloudproxy/providers/aws/main.py
@@ -83,7 +83,7 @@ def aws_check_delete():
 
 
 def aws_start():
+    aws_check_delete()
     aws_deployment(config["providers"]["aws"]["scaling"]["min_scaling"])
     ip_ready = aws_check_alive()
-    aws_check_delete()
     return ip_ready

--- a/cloudproxy/providers/config.py
+++ b/cloudproxy/providers/config.py
@@ -7,5 +7,6 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 def set_auth(username, password):
     with open(os.path.join(__location__, "user_data.sh")) as file:
         filedata = file.read()
-        filedata = filedata.replace("username:password", username + ":" + password)
+        filedata = filedata.replace("username", username)
+        filedata = filedata.replace("password", password)
     return filedata

--- a/cloudproxy/providers/digitalocean/main.py
+++ b/cloudproxy/providers/digitalocean/main.py
@@ -69,15 +69,10 @@ def do_check_delete():
             delete_proxy(droplet)
             logger.info("Destroyed: not wanted -> " + str(droplet.ip_address))
             delete_queue.remove(droplet.ip_address)
-            return True
-        else:
-            return False
 
 
 def do_start():
-    do_deployment(
-        settings.config["providers"]["digitalocean"]["scaling"]["min_scaling"]
-    )
-    ip_ready = do_check_alive()
     do_check_delete()
+    do_deployment(settings.config["providers"]["digitalocean"]["scaling"]["min_scaling"])
+    ip_ready = do_check_alive()
     return ip_ready

--- a/cloudproxy/providers/digitalocean/main.py
+++ b/cloudproxy/providers/digitalocean/main.py
@@ -11,7 +11,7 @@ from cloudproxy.providers.digitalocean.functions import (
     delete_proxy,
 )
 from cloudproxy.providers import settings
-from cloudproxy.providers.settings import delete_queue, config
+from cloudproxy.providers.settings import delete_queue, restart_queue, config
 
 
 def do_deployment(min_scaling):
@@ -65,7 +65,7 @@ def do_check_alive():
 
 def do_check_delete():
     for droplet in list_droplets():
-        if droplet.ip_address in delete_queue:
+        if droplet.ip_address in delete_queue or droplet.ip_address in restart_queue:
             delete_proxy(droplet)
             logger.info("Destroyed: not wanted -> " + str(droplet.ip_address))
             delete_queue.remove(droplet.ip_address)

--- a/cloudproxy/providers/manager.py
+++ b/cloudproxy/providers/manager.py
@@ -20,11 +20,13 @@ def aws_manager():
 def init_schedule():
     sched = BackgroundScheduler()
     sched.start()
-    if settings.config["providers"]["digitalocean"]["enabled"]:
+    if settings.config["providers"]["digitalocean"]["enabled"] == 'True':
         sched.add_job(do_manager, "interval", seconds=20)
+        do_manager()
     else:
         logger.info("DigitalOcean not enabled")
-    if settings.config["providers"]["aws"]["enabled"]:
+    if settings.config["providers"]["aws"]["enabled"] == 'True':
         sched.add_job(aws_manager, "interval", seconds=20)
+        aws_manager()
     else:
         logger.info("AWS not enabled")

--- a/cloudproxy/providers/manager.py
+++ b/cloudproxy/providers/manager.py
@@ -22,11 +22,9 @@ def init_schedule():
     sched.start()
     if settings.config["providers"]["digitalocean"]["enabled"] == 'True':
         sched.add_job(do_manager, "interval", seconds=20)
-        do_manager()
     else:
         logger.info("DigitalOcean not enabled")
     if settings.config["providers"]["aws"]["enabled"] == 'True':
         sched.add_job(aws_manager, "interval", seconds=20)
-        aws_manager()
     else:
         logger.info("AWS not enabled")

--- a/cloudproxy/providers/settings.py
+++ b/cloudproxy/providers/settings.py
@@ -25,6 +25,7 @@ config = {
 }
 
 delete_queue = set()
+restart_queue = set()
 
 load_dotenv()
 

--- a/cloudproxy/providers/settings.py
+++ b/cloudproxy/providers/settings.py
@@ -41,10 +41,10 @@ config["providers"]["digitalocean"]["secrets"]["access_token"] = os.environ.get(
     "DIGITALOCEAN_ACCESS_TOKEN"
 )
 config["providers"]["digitalocean"]["scaling"]["min_scaling"] = int(
-    os.environ.get("DIGITALOCEAN_MIN_SCALE", 2)
+    os.environ.get("DIGITALOCEAN_MIN_SCALING", 2)
 )
 config["providers"]["digitalocean"]["scaling"]["max_scaling"] = int(
-    os.environ.get("DIGITALOCEAN_MAX_SCALE", 2)
+    os.environ.get("DIGITALOCEAN_MAX_SCALING", 2)
 )
 config["providers"]["digitalocean"]["size"] = os.environ.get(
     "DIGITALOCEAN_SIZE", "s-1vcpu-1gb"
@@ -62,10 +62,10 @@ config["providers"]["aws"]["secrets"]["secret_access_key"] = os.environ.get(
     "AWS_SECRET_ACCESS_KEY"
 )
 config["providers"]["aws"]["scaling"]["min_scaling"] = int(
-    os.environ.get("AWS_MIN_SCALE", 2)
+    os.environ.get("AWS_MIN_SCALING", 2)
 )
 config["providers"]["aws"]["scaling"]["max_scaling"] = int(
-    os.environ.get("AWS_MAX_SCALE", 2)
+    os.environ.get("AWS_MAX_SCALING", 2)
 )
 config["providers"]["aws"]["size"] = os.environ.get("AWS_SIZE", "t2.micro")
 config["providers"]["aws"]["region"] = os.environ.get("AWS_REGION", "eu-west-2")

--- a/cloudproxy/providers/user_data.sh
+++ b/cloudproxy/providers/user_data.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-apt-get -y update
-sudo apt install apt-transport-https ca-certificates curl software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
-sudo apt update
-apt-get -y install docker-ce docker-ce-cli containerd.io
-docker run -d -p 8899:8899 --rm abhinavsingh/proxy.py:v2.3.1 --hostname 0.0.0.0 --basic-auth username:password
-ufw default deny incoming
-ufw default allow outgoing
-ufw allow 8899/tcp
-ufw --force enable
+sudo apt-get -y update
+sudo apt-get install -y ca-certificates tinyproxy
+sudo sed -i 's/Port 8888/Port 8899/g' /etc/tinyproxy/tinyproxy.conf
+sudo sed -i 's/Allow 127.0.0.1/#Allow 127.0.0.1/g' /etc/tinyproxy/tinyproxy.conf
+sudo sed -i 's/#BasicAuth user pass.*/BasicAuth username password/g' /etc/tinyproxy/tinyproxy.conf
+sudo systemctl restart tinyproxy
+sudo ufw default deny incoming
+sudo ufw allow 22/tcp
+sudo ufw allow 8899/tcp
+sudo ufw --force enable

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ python-digitalocean==1.16.0
 boto3==1.17.55
 urllib3==1.26.4
 aiofiles==0.6.0
+botocore~=1.20.84

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,9 +1,0 @@
-from cloudproxy.check import check_alive
-
-
-def test_check_alive(mocker):
-    mocker.patch(
-        'cloudproxy.check.fetch_ip',
-        return_value="192.1.1.1"
-    )
-    assert check_alive("192.1.1.1") == True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,7 +21,7 @@ def test_random():
 def test_remove_proxy():
     response = client.delete("/destroy?ip_address=192.168.0.0")
     assert response.status_code == 200
-    assert response.json() == ["Proxy to be destroyed"]
+    assert response.json() == ["Proxy <192.168.0.0> to be destroyed"]
     assert delete_queue == {"192.168.0.0"}
 
 

--- a/tests/test_providers_digitalocean_config.py
+++ b/tests/test_providers_digitalocean_config.py
@@ -8,4 +8,4 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 def test_set_auth():
     with open(os.path.join(__location__, 'test_user_data.sh')) as file:
         filedata = file.read()
-    assert set_auth("testingusername", "testingusername") == filedata
+    assert set_auth("testingusername", "testinguserpassword") == filedata

--- a/tests/test_user_data.sh
+++ b/tests/test_user_data.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-apt-get -y update
-sudo apt install apt-transport-https ca-certificates curl software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
-sudo apt update
-apt-get -y install docker-ce docker-ce-cli containerd.io
-docker run -d -p 8899:8899 --rm abhinavsingh/proxy.py:v2.3.1 --hostname 0.0.0.0 --basic-auth testingusername:testingusername
-ufw default deny incoming
-ufw default allow outgoing
-ufw allow 8899/tcp
-ufw --force enable
+sudo apt-get -y update
+sudo apt-get install -y ca-certificates tinyproxy
+sudo sed -i 's/Port 8888/Port 8899/g' /etc/tinyproxy/tinyproxy.conf
+sudo sed -i 's/Allow 127.0.0.1/#Allow 127.0.0.1/g' /etc/tinyproxy/tinyproxy.conf
+sudo sed -i 's/#BasicAuth user pass.*/BasicAuth testingusername testinguserpassword/g' /etc/tinyproxy/tinyproxy.conf
+sudo systemctl restart tinyproxy
+sudo ufw default deny incoming
+sudo ufw allow 22/tcp
+sudo ufw allow 8899/tcp
+sudo ufw --force enable


### PR DESCRIPTION
Quite a few changes you might want to cherrypick something from, top to bottom:
- change retries to 1 and set a timeout of 10s on fetch_ip
- rewrote the check_alive function to be much simpler, the fetch_ip check was not viable at 20+ proxies. It took too long.
- updated ip_list not to return ip:s slated for destruction
- added option to restart AWS proxies, much faster than destroy/create and fetches a new IP. Not supported for DO.
- opened up port 22 on proxies for debugging, future enhancement is to only allow web control. (Use the EC2_INSTANCE_CONNECT filter for the service parameter to get the IP address ranges in the EC2 Instance Connect subset. )
- enhanced status messages a bit in the check_alive for AWS
- moved check_delete/stop to before provision so it removes and then immediately provisions a new one instead of waiting 20s for next tick
- changed the proxy software to tinyproxy directly on the image instead of using docker. Much faster deployment and less cpu intensive so should work better with t2.nano
- updated the settings checks to compare true/false as a string since it seems to be what it is getting, earlier a value of False in the config would read as true.
- updated environ get to match the doc (ie SCALING instead of SCALE)
- added botocore to requirements.txt, seemed to be missing.
