### PR TITLE
Creating a Firewall for Digital Ocean

### DIFF
--- a/cloudproxy/providers/digitalocean/functions.py
+++ b/cloudproxy/providers/digitalocean/functions.py
@@ -14,6 +14,8 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 
 token = settings.config["providers"]["digitalocean"]["secrets"]["access_token"]
 
+class DOFirewallExistsException(Exception):
+    pass
 
 def create_proxy():
     user_data = set_auth(
@@ -39,3 +41,50 @@ def delete_proxy(droplet_id):
 def list_droplets():
     my_droplets = manager.get_all_droplets(tag_name="cloudproxy")
     return my_droplets
+
+def create_firewall():
+    fw = digitalocean.Firewall(
+            name="cloudproxy",
+            inbound_rules=__create_inbound_fw_rules(),
+            outbound_rules=__create_outbound_fw_rules(),
+            tags=["cloudproxy"]
+         )
+    try:
+        fw.create()
+    except digitalocean.DataReadError as dre:
+        if dre.args[0] == 'duplicate name':
+            raise DOFirewallExistsException("Firewall already exists for 'cloudproxy'")
+        else:
+            raise
+
+def __create_inbound_fw_rules():
+    return [
+        digitalocean.InboundRule(
+            protocol="tcp", 
+            ports="8899", 
+            sources=digitalocean.Sources(addresses=[
+                            "0.0.0.0/0",
+                            "::/0"]
+                        )
+            )
+    ]
+
+def __create_outbound_fw_rules():
+    return [
+        digitalocean.OutboundRule(
+            protocol="tcp",
+            ports="all",
+            destinations=digitalocean.Destinations(addresses=[
+                            "0.0.0.0/0",
+                            "::/0"]
+                        )
+            ),
+        digitalocean.OutboundRule(
+            protocol="udp",
+            ports="all",
+            destinations=digitalocean.Destinations(addresses=[
+                            "0.0.0.0/0",
+                            "::/0"]
+                        )
+            )
+    ]

--- a/cloudproxy/providers/digitalocean/main.py
+++ b/cloudproxy/providers/digitalocean/main.py
@@ -9,6 +9,8 @@ from cloudproxy.providers.digitalocean.functions import (
     create_proxy,
     list_droplets,
     delete_proxy,
+    create_firewall,
+    DOFirewallExistsException,
 )
 from cloudproxy.providers import settings
 from cloudproxy.providers.settings import delete_queue, restart_queue, config
@@ -70,8 +72,17 @@ def do_check_delete():
             logger.info("Destroyed: not wanted -> " + str(droplet.ip_address))
             delete_queue.remove(droplet.ip_address)
 
+def do_fw():
+    try:
+        create_firewall()
+        logger.info("Created firewall 'cloudproxy'")
+    except DOFirewallExistsException as e:
+        pass
+    except Exception as e:
+        logger.error(e)
 
 def do_start():
+    do_fw()
     do_check_delete()
     do_deployment(settings.config["providers"]["digitalocean"]["scaling"]["min_scaling"])
     ip_ready = do_check_alive()


### PR DESCRIPTION
Using the 'cloudproxy' tag for firewall assignment.
All existing and future proxy created droplets will use the aforementioned firewall.