### PR TITLE
age_limit control flow bugfix

### DIFF
--- a/cloudproxy/providers/aws/main.py
+++ b/cloudproxy/providers/aws/main.py
@@ -46,12 +46,11 @@ def aws_check_alive():
             elapsed = datetime.datetime.now(
                 datetime.timezone.utc
             ) - instance["Instances"][0]["LaunchTime"]
-            if config["age_limit"] > 0:
-                if elapsed > datetime.timedelta(seconds=config["age_limit"]):
-                    delete_proxy(instance["Instances"][0]["InstanceId"])
-                    logger.info(
-                        "Recycling droplet, reached age limit -> " + instance["Instances"][0]["PublicIpAddress"]
-                    )
+            if config["age_limit"] > 0 and elapsed > datetime.timedelta(seconds=config["age_limit"]):
+                delete_proxy(instance["Instances"][0]["InstanceId"])
+                logger.info(
+                    "Recycling droplet, reached age limit -> " + instance["Instances"][0]["PublicIpAddress"]
+                )
             elif instance["Instances"][0]["State"]["Name"] == "stopped":
                 logger.info(
                     "Waking up: AWS -> Instance " + instance["Instances"][0]["InstanceId"]

--- a/cloudproxy/providers/digitalocean/main.py
+++ b/cloudproxy/providers/digitalocean/main.py
@@ -41,12 +41,11 @@ def do_check_alive():
             elapsed = datetime.datetime.now(
                 datetime.timezone.utc
             ) - dateparser.parse(droplet.created_at)
-            if config["age_limit"] > 0:
-                if elapsed > datetime.timedelta(seconds=config["age_limit"]):
-                    delete_proxy(droplet)
-                    logger.info(
-                        "Recycling droplet, reached age limit -> " + str(droplet.ip_address)
-                    )
+            if config["age_limit"] > 0 and elapsed > datetime.timedelta(seconds=config["age_limit"]):
+                delete_proxy(droplet)
+                logger.info(
+                    "Recycling droplet, reached age limit -> " + str(droplet.ip_address)
+                )
             elif check_alive(droplet.ip_address):
                 logger.info("Alive: DO -> " + str(droplet.ip_address))
                 ip_ready.append(droplet.ip_address)

--- a/cloudproxy/providers/hetzner/main.py
+++ b/cloudproxy/providers/hetzner/main.py
@@ -36,12 +36,11 @@ def hetzner_check_alive():
         elapsed = datetime.datetime.now(
             datetime.timezone.utc
         ) - dateparser.parse(str(proxy.created))
-        if config["age_limit"] > 0:
-            if elapsed > datetime.timedelta(seconds=config["age_limit"]):
-                delete_proxy(proxy)
-                logger.info(
-                    "Recycling proxy, reached age limit -> " + str(proxy.public_net.ipv4.ip)
-                )
+        if config["age_limit"] > 0 and elapsed > datetime.timedelta(seconds=config["age_limit"]):
+            delete_proxy(proxy)
+            logger.info(
+                "Recycling proxy, reached age limit -> " + str(proxy.public_net.ipv4.ip)
+            )
         elif check_alive(proxy.public_net.ipv4.ip):
             logger.info("Alive: Hetzner -> " + str(proxy.public_net.ipv4.ip))
             ip_ready.append(proxy.public_net.ipv4.ip)


### PR DESCRIPTION
If age_limit is specified for providers other than gcp, the control flow won't update ip_ready with alive proxies.

My proposed solution involves copying the logic from gcp_check_alive() where the age_limit > 0 check is combined with the elapsed check.