### PR TITLE
Cancel spot requests when associated instances are terminated

### DIFF
--- a/cloudproxy/providers/aws/functions.py
+++ b/cloudproxy/providers/aws/functions.py
@@ -99,19 +99,20 @@ def create_proxy():
 def delete_proxy(instance_id):
     ids = [instance_id]
     deleted = ec2.instances.filter(InstanceIds=ids).terminate()
-    associated_spot_instance_requests = ec2_client.describe_spot_instance_requests(
-        Filters=[
-            {
-                'Name': 'instance-id',
-                'Values': ids
-            }
-        ]
-    )
-    spot_instance_id_list = []
-    for spot_instance in associated_spot_instance_requests["SpotInstanceRequests"]:
-        spot_instance_id_list.append(spot_instance.get("SpotInstanceRequestId"))
-    if spot_instance_id_list:
-        ec2_client.cancel_spot_instance_requests(SpotInstanceRequestIds=spot_instance_id_list)
+    if config["providers"]["aws"]["spot"] == 'one-time':
+        associated_spot_instance_requests = ec2_client.describe_spot_instance_requests(
+            Filters=[
+                {
+                    'Name': 'instance-id',
+                    'Values': ids
+                }
+            ]
+        )
+        spot_instance_id_list = []
+        for spot_instance in associated_spot_instance_requests["SpotInstanceRequests"]:
+            spot_instance_id_list.append(spot_instance.get("SpotInstanceRequestId"))
+        if spot_instance_id_list:
+            ec2_client.cancel_spot_instance_requests(SpotInstanceRequestIds=spot_instance_id_list)
     return deleted
 
 

--- a/cloudproxy/providers/aws/functions.py
+++ b/cloudproxy/providers/aws/functions.py
@@ -99,7 +99,7 @@ def create_proxy():
 def delete_proxy(instance_id):
     ids = [instance_id]
     deleted = ec2.instances.filter(InstanceIds=ids).terminate()
-    if config["providers"]["aws"]["spot"] == 'one-time':
+    if config["providers"]["aws"]["spot"]:
         associated_spot_instance_requests = ec2_client.describe_spot_instance_requests(
             Filters=[
                 {

--- a/cloudproxy/providers/aws/functions.py
+++ b/cloudproxy/providers/aws/functions.py
@@ -99,6 +99,19 @@ def create_proxy():
 def delete_proxy(instance_id):
     ids = [instance_id]
     deleted = ec2.instances.filter(InstanceIds=ids).terminate()
+    associated_spot_instance_requests = ec2_client.describe_spot_instance_requests(
+        Filters=[
+            {
+                'Name': 'instance-id',
+                'Values': ids
+            }
+        ]
+    )
+    spot_instance_id_list = []
+    for spot_instance in associated_spot_instance_requests["SpotInstanceRequests"]:
+        spot_instance_id_list.append(spot_instance.get("SpotInstanceRequestId"))
+    if spot_instance_id_list:
+        ec2_client.cancel_spot_instance_requests(SpotInstanceRequestIds=spot_instance_id_list)
     return deleted
 
 


### PR DESCRIPTION
When deleting proxies filled by one-time spot requests, the instances are terminated, but the spot request itself is not cancelled, leaving the door open to being filled again in the future when not associated with cloudproxy. This PR deletes the spot request if it exists in the delete_proxy() function. Related to #42, but unclear if applicable to persistent spot requests.