### PR TITLE
Allowed IP as alternative auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ or/and
 ##### Optional
 
 `` AGE_LIMIT`` - set the age limit for your forward proxies in seconds. Once the age limit is reached, the proxy is replaced. A value of 0 disables the feature. Default value: 0.
+
 `` PROXY_STEALTH `` remove request proxy headers. Tinyproxy quote: "Note that RFC 2616 requires proxies to set the Via header, so by enabling this option, you break compliance. Don't disable the Via header unless you know what you are doing..." Default: false
 
 See individual provider pages for environment variables required in above providers supported section.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For example:
        -e PASSWORD='CHANGE_THIS_PASSWORD' \
        -e DIGITALOCEAN_ENABLED=true \
        -e DIGITALOCEAN_ACCESS_TOKEN='YOUR SECRET ACCESS KEY' \
-       -it -p 8000:8000 laffin/cloudproxy:latest
+       -it -p 127.0.0.1:8000:8000 laffin/cloudproxy:latest
    ```
 
 It is recommended to use a Docker image tagged to a version e.g. `laffin/cloudproxy:0.6.0-beta`, see [releases](https://github.com/claffin/cloudproxy/releases) for latest version.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ or/and
 
 `` AGE_LIMIT`` - set the age limit for your forward proxies in seconds. Once the age limit is reached, the proxy is replaced. A value of 0 disables the feature. Default value: 0.
 
-`` PROXY_STEALTH `` remove request proxy headers. Tinyproxy quote: "Note that RFC 2616 requires proxies to set the Via header, so by enabling this option, you break compliance. Don't disable the Via header unless you know what you are doing..." Default: false
+`` PROXY_STEALTH `` - remove request proxy headers. Tinyproxy quote: "Note that RFC 2616 requires proxies to set the Via header, so by enabling this option, you break compliance. Don't disable the Via header unless you know what you are doing..." Default: false
 
 See individual provider pages for environment variables required in above providers supported section.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ All you need is:
 ##### Required
 - `USERNAME` - set the username for the forward proxy.
 - `PASSWORD` - set the password for the forward proxy.
+
 or/and
+
 - `ALLOWED_IP` - set allowed ip to use proxy.
 
 ##### Optional

--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ All you need is:
 ##### Required
 - `USERNAME` - set the username for the forward proxy.
 - `PASSWORD` - set the password for the forward proxy.
+or/and
+- `ALLOWED_IP` - set allowed ip to use proxy.
 
 ##### Optional
 
 `` AGE_LIMIT`` - set the age limit for your forward proxies in seconds. Once the age limit is reached, the proxy is replaced. A value of 0 disables the feature. Default value: 0.
+`` PROXY_STEALTH `` remove request proxy headers. Tinyproxy quote: "Note that RFC 2616 requires proxies to set the Via header, so by enabling this option, you break compliance. Don't disable the Via header unless you know what you are doing..." Default: false
 
 See individual provider pages for environment variables required in above providers supported section.
 
@@ -68,7 +71,7 @@ For example:
    ```shell
    docker run -e USERNAME='CHANGE_THIS_USERNAME' \
        -e PASSWORD='CHANGE_THIS_PASSWORD' \
-       -e DIGITALOCEAN_ENABLED=True \
+       -e DIGITALOCEAN_ENABLED=true \
        -e DIGITALOCEAN_ACCESS_TOKEN='YOUR SECRET ACCESS KEY' \
        -it -p 8000:8000 laffin/cloudproxy:latest
    ```

--- a/cloudproxy/check.py
+++ b/cloudproxy/check.py
@@ -48,7 +48,7 @@ def check_alive(ip_address):
             "http": "http://" + ip_address + ":8899",
             "https": "http://" + ip_address + ":8899"
         }
-        result = requests.get("http://google.es", timeout=3, proxies=proxies)
+        result = requests.get("http://google.es", timeout=6, proxies=proxies)
         if result.status_code in (200, 407):
             return True
         else:

--- a/cloudproxy/check.py
+++ b/cloudproxy/check.py
@@ -44,7 +44,13 @@ def fetch_ip(ip_address):
 
 def check_alive(ip_address):
     try:
-        result = requests.get("http://" + ip_address + ":8899", timeout=3)
+        proxies = {
+            "http": "http://" + ip_address + ":8899",
+            "https": "http://" + ip_address + ":8899"
+        }
+        result = requests.get("http://google.es", timeout=3, proxies=proxies)
+        print("http://" + ip_address + ":8899")
+        print(result)
         if result.status_code in (200, 407):
             return True
         else:

--- a/cloudproxy/check.py
+++ b/cloudproxy/check.py
@@ -49,8 +49,6 @@ def check_alive(ip_address):
             "https": "http://" + ip_address + ":8899"
         }
         result = requests.get("http://google.es", timeout=3, proxies=proxies)
-        print("http://" + ip_address + ":8899")
-        print(result)
         if result.status_code in (200, 407):
             return True
         else:

--- a/cloudproxy/main.py
+++ b/cloudproxy/main.py
@@ -46,15 +46,22 @@ def get_ip_list():
         if settings.config["providers"][provider]["ips"]:
             for ip in settings.config["providers"][provider]["ips"]:
                 if ip not in delete_queue and ip not in restart_queue:
-                    ip_list.append(
-                        "http://"
-                        + settings.config["auth"]["username"]
-                        + ":"
-                        + settings.config["auth"]["password"]
-                        + "@"
-                        + ip
-                        + ":8899"
-                    )
+                    if settings.config["auth"]["username"] != "changeme":
+                        ip_list.append(
+                            "http://"
+                            + settings.config["auth"]["username"]
+                            + ":"
+                            + settings.config["auth"]["password"]
+                            + "@"
+                            + ip
+                            + ":8899"
+                        )
+                    else:
+                        ip_list.append(
+                            "http://"
+                            + ip
+                            + ":8899"
+                        )  
     return ip_list
 
 

--- a/cloudproxy/providers/aws/functions.py
+++ b/cloudproxy/providers/aws/functions.py
@@ -43,27 +43,28 @@ def create_proxy():
         pass
     sg_id = ec2_client.describe_security_groups(GroupNames=["cloudproxy"])
     sg_id = sg_id["SecurityGroups"][0]["GroupId"]
-    if config["providers"]["aws"]["spot"] == 'persistent':
-        instance = ec2.create_instances(
-            ImageId=config["providers"]["aws"]["ami"],
-            MinCount=1,
-            MaxCount=1,
-            InstanceType=config["providers"]["aws"]["size"],
-            NetworkInterfaces=[
-                {"DeviceIndex": 0, "AssociatePublicIpAddress": True, "Groups": [sg_id]}
-            ],
-            InstanceMarketOptions={
-                "MarketType": "spot",
-                "SpotOptions": {
-                    "InstanceInterruptionBehavior": "stop",
-                    "SpotInstanceType": "persistent"
-                }
-            },
-            KeyName=config["providers"]["aws"]["key_name"],
-            TagSpecifications=tag_specification,
-            UserData=user_data,
-        )
-    elif config["providers"]["aws"]["spot"] == 'one-time':
+    if (config["providers"]["aws"]["key_name"] != ""):
+        if config["providers"]["aws"]["spot"] == 'persistent':
+            instance = ec2.create_instances(
+                ImageId=config["providers"]["aws"]["ami"],
+                MinCount=1,
+                MaxCount=1,
+                InstanceType=config["providers"]["aws"]["size"],
+                NetworkInterfaces=[
+                    {"DeviceIndex": 0, "AssociatePublicIpAddress": True, "Groups": [sg_id]}
+                ],
+                InstanceMarketOptions={
+                    "MarketType": "spot",
+                    "SpotOptions": {
+                        "InstanceInterruptionBehavior": "stop",
+                        "SpotInstanceType": "persistent"
+                    }
+                },
+                KeyName=config["providers"]["aws"]["key_name"],
+                TagSpecifications=tag_specification,
+                UserData=user_data,
+            )
+        elif config["providers"]["aws"]["spot"] == 'one-time':
             instance = ec2.create_instances(
                 ImageId=config["providers"]["aws"]["ami"],
                 MinCount=1,
@@ -83,19 +84,70 @@ def create_proxy():
                 TagSpecifications=tag_specification,
                 UserData=user_data,
             )
+        else:
+            instance = ec2.create_instances(
+                ImageId=config["providers"]["aws"]["ami"],
+                MinCount=1,
+                MaxCount=1,
+                InstanceType=config["providers"]["aws"]["size"],
+                NetworkInterfaces=[
+                    {"DeviceIndex": 0, "AssociatePublicIpAddress": True, "Groups": [sg_id]}
+                ],
+                KeyName=config["providers"]["aws"]["key_name"],
+                TagSpecifications=tag_specification,
+                UserData=user_data,
+            )
     else:
-        instance = ec2.create_instances(
-            ImageId=config["providers"]["aws"]["ami"],
-            MinCount=1,
-            MaxCount=1,
-            InstanceType=config["providers"]["aws"]["size"],
-            NetworkInterfaces=[
-                {"DeviceIndex": 0, "AssociatePublicIpAddress": True, "Groups": [sg_id]}
-            ],
-            KeyName=config["providers"]["aws"]["key_name"],
-            TagSpecifications=tag_specification,
-            UserData=user_data,
-        )
+        if config["providers"]["aws"]["spot"] == 'persistent':
+            instance = ec2.create_instances(
+                ImageId=config["providers"]["aws"]["ami"],
+                MinCount=1,
+                MaxCount=1,
+                InstanceType=config["providers"]["aws"]["size"],
+                NetworkInterfaces=[
+                    {"DeviceIndex": 0, "AssociatePublicIpAddress": True, "Groups": [sg_id]}
+                ],
+                InstanceMarketOptions={
+                    "MarketType": "spot",
+                    "SpotOptions": {
+                        "InstanceInterruptionBehavior": "stop",
+                        "SpotInstanceType": "persistent"
+                    }
+                },
+                TagSpecifications=tag_specification,
+                UserData=user_data,
+            )
+        elif config["providers"]["aws"]["spot"] == 'one-time':
+            instance = ec2.create_instances(
+                ImageId=config["providers"]["aws"]["ami"],
+                MinCount=1,
+                MaxCount=1,
+                InstanceType=config["providers"]["aws"]["size"],
+                NetworkInterfaces=[
+                    {"DeviceIndex": 0, "AssociatePublicIpAddress": True, "Groups": [sg_id]}
+                ],
+                InstanceMarketOptions={
+                    "MarketType": "spot",
+                    "SpotOptions": {
+                        "InstanceInterruptionBehavior": "terminate",
+                        "SpotInstanceType": "one-time"
+                    }
+                },
+                TagSpecifications=tag_specification,
+                    UserData=user_data,
+            )
+        else:
+            instance = ec2.create_instances(
+                ImageId=config["providers"]["aws"]["ami"],
+                MinCount=1,
+                MaxCount=1,
+                InstanceType=config["providers"]["aws"]["size"],
+                NetworkInterfaces=[
+                    {"DeviceIndex": 0, "AssociatePublicIpAddress": True, "Groups": [sg_id]}
+                ],
+                TagSpecifications=tag_specification,
+                UserData=user_data,
+            ) 
     return instance
 
 

--- a/cloudproxy/providers/aws/functions.py
+++ b/cloudproxy/providers/aws/functions.py
@@ -4,7 +4,7 @@ import json
 import botocore as botocore
 import botocore.exceptions
 
-from cloudproxy.providers.config import set_auth
+from cloudproxy.providers.config import set_proxy
 from cloudproxy.providers.settings import config
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
@@ -28,7 +28,7 @@ def create_proxy():
 
         if response["Vpcs"][0]["IsDefault"]:
             default_vpc = response["Vpcs"][0]["VpcId"]
-    user_data = set_auth(config["auth"]["username"], config["auth"]["password"], config["auth"]["allowed_ip"])
+    user_data = set_proxy(config["auth"]["username"], config["auth"]["password"], config["auth"]["allowed_ip"], config["proxy_stealth"])
     try:
         sg = ec2.create_security_group(
             Description="SG for CloudProxy", GroupName="cloudproxy", VpcId=default_vpc

--- a/cloudproxy/providers/aws/functions.py
+++ b/cloudproxy/providers/aws/functions.py
@@ -28,7 +28,7 @@ def create_proxy():
 
         if response["Vpcs"][0]["IsDefault"]:
             default_vpc = response["Vpcs"][0]["VpcId"]
-    user_data = set_auth(config["auth"]["username"], config["auth"]["password"])
+    user_data = set_auth(config["auth"]["username"], config["auth"]["password"], config["auth"]["allowed_ip"])
     try:
         sg = ec2.create_security_group(
             Description="SG for CloudProxy", GroupName="cloudproxy", VpcId=default_vpc

--- a/cloudproxy/providers/aws/functions.py
+++ b/cloudproxy/providers/aws/functions.py
@@ -59,6 +59,7 @@ def create_proxy():
                     "SpotInstanceType": "persistent"
                 }
             },
+            KeyName=config["providers"]["aws"]["key_name"],
             TagSpecifications=tag_specification,
             UserData=user_data,
         )
@@ -78,6 +79,7 @@ def create_proxy():
                         "SpotInstanceType": "one-time"
                     }
                 },
+                KeyName=config["providers"]["aws"]["key_name"],
                 TagSpecifications=tag_specification,
                 UserData=user_data,
             )
@@ -90,6 +92,7 @@ def create_proxy():
             NetworkInterfaces=[
                 {"DeviceIndex": 0, "AssociatePublicIpAddress": True, "Groups": [sg_id]}
             ],
+            KeyName=config["providers"]["aws"]["key_name"],
             TagSpecifications=tag_specification,
             UserData=user_data,
         )

--- a/cloudproxy/providers/config.py
+++ b/cloudproxy/providers/config.py
@@ -13,5 +13,5 @@ def set_auth(username, password, allowed_ip):
         else:
             filedata = filedata.replace("BasicAuth username password", "#BasicAuth username password")
         if len(allowed_ip) > 0:
-            filedata = filedata.replace("#Allow 127.0.0.1", "Allow " + allowed_ip)
+            filedata = filedata.replace("#Allow 127.0.0.1", "Allow " + allowed_ip + "\/24")
     return filedata

--- a/cloudproxy/providers/config.py
+++ b/cloudproxy/providers/config.py
@@ -4,9 +4,14 @@ import os
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 
-def set_auth(username, password):
+def set_auth(username, password, allowed_ip):
     with open(os.path.join(__location__, "user_data.sh")) as file:
         filedata = file.read()
-        filedata = filedata.replace("username", username)
-        filedata = filedata.replace("password", password)
+        if username != "changeme":
+            filedata = filedata.replace("username", username)
+            filedata = filedata.replace("password", password)
+        else:
+            filedata = filedata.replace("BasicAuth username password", "#BasicAuth username password")
+        if len(allowed_ip) > 0:
+            filedata = filedata.replace("#Allow 127.0.0.1", "Allow " + allowed_ip)
     return filedata

--- a/cloudproxy/providers/config.py
+++ b/cloudproxy/providers/config.py
@@ -4,7 +4,7 @@ import os
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 
-def set_auth(username, password, allowed_ip):
+def set_proxy(username, password, allowed_ip, proxy_stealth):
     with open(os.path.join(__location__, "user_data.sh")) as file:
         filedata = file.read()
         if username != "changeme":
@@ -14,4 +14,6 @@ def set_auth(username, password, allowed_ip):
             filedata = filedata.replace("BasicAuth username password", "#BasicAuth username password")
         if len(allowed_ip) > 0:
             filedata = filedata.replace("#Allow 127.0.0.1", "Allow " + allowed_ip + "\/24")
+        if proxy_stealth:
+            filedata = filedata.replace("DisableViaHeader No", "DisableViaHeader Yes")
     return filedata

--- a/cloudproxy/providers/digitalocean/functions.py
+++ b/cloudproxy/providers/digitalocean/functions.py
@@ -5,7 +5,7 @@ import uuid as uuid
 
 from cloudproxy.check import check_alive
 from cloudproxy.providers import settings
-from cloudproxy.providers.config import set_auth
+from cloudproxy.providers.config import set_proxy
 
 manager = digitalocean.Manager(
     token=settings.config["providers"]["digitalocean"]["secrets"]["access_token"]
@@ -18,8 +18,11 @@ class DOFirewallExistsException(Exception):
     pass
 
 def create_proxy():
-    user_data = set_auth(
-        settings.config["auth"]["username"], settings.config["auth"]["password"], settings.config["auth"]["allowed_ip"]
+    user_data = set_proxy(
+        settings.config["auth"]["username"],
+        settings.config["auth"]["password"],
+        settings.config["auth"]["allowed_ip"],
+        settings.config["auth"]["proxy_stealth"]
     )
     digitalocean.Droplet(
         name=str(uuid.uuid1()),

--- a/cloudproxy/providers/digitalocean/functions.py
+++ b/cloudproxy/providers/digitalocean/functions.py
@@ -19,7 +19,7 @@ class DOFirewallExistsException(Exception):
 
 def create_proxy():
     user_data = set_auth(
-        settings.config["auth"]["username"], settings.config["auth"]["password"]
+        settings.config["auth"]["username"], settings.config["auth"]["password"], settings.config["auth"]["allowed_ip"]
     )
     digitalocean.Droplet(
         name=str(uuid.uuid1()),

--- a/cloudproxy/providers/digitalocean/functions.py
+++ b/cloudproxy/providers/digitalocean/functions.py
@@ -22,7 +22,7 @@ def create_proxy():
         settings.config["auth"]["username"],
         settings.config["auth"]["password"],
         settings.config["auth"]["allowed_ip"],
-        settings.config["auth"]["proxy_stealth"]
+        settings.config["proxy_stealth"]
     )
     digitalocean.Droplet(
         name=str(uuid.uuid1()),

--- a/cloudproxy/providers/gcp/functions.py
+++ b/cloudproxy/providers/gcp/functions.py
@@ -61,7 +61,7 @@ def create_proxy():
         'metadata': {
             'items': [{
                 'key': 'startup-script',
-                'value': set_auth(config["auth"]["username"], config["auth"]["password"])
+                'value': set_auth(config["auth"]["username"], config["auth"]["password"], config["auth"]["allowed_ip"])
             }]
         }
     }

--- a/cloudproxy/providers/gcp/functions.py
+++ b/cloudproxy/providers/gcp/functions.py
@@ -6,7 +6,7 @@ from loguru import logger
 import googleapiclient.discovery
 from google.oauth2 import service_account
 
-from cloudproxy.providers.config import set_auth
+from cloudproxy.providers.config import set_proxy
 from cloudproxy.providers.settings import config
 
 gcp = config["providers"]["gcp"]
@@ -61,7 +61,7 @@ def create_proxy():
         'metadata': {
             'items': [{
                 'key': 'startup-script',
-                'value': set_auth(config["auth"]["username"], config["auth"]["password"], config["auth"]["allowed_ip"])
+                'value': set_proxy(config["auth"]["username"], config["auth"]["password"], config["auth"]["allowed_ip"], config["proxy_stealth"])
             }]
         }
     }

--- a/cloudproxy/providers/hetzner/functions.py
+++ b/cloudproxy/providers/hetzner/functions.py
@@ -16,7 +16,7 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 
 def create_proxy():
     user_data = set_auth(
-        settings.config["auth"]["username"], settings.config["auth"]["password"]
+        settings.config["auth"]["username"], settings.config["auth"]["password"], settings.config["auth"]["allowed_ip"]
     )
     client.servers.create(name=str(uuid.uuid1()),
                           server_type=ServerType("cx11"),

--- a/cloudproxy/providers/hetzner/functions.py
+++ b/cloudproxy/providers/hetzner/functions.py
@@ -8,15 +8,18 @@ from hcloud.datacenters.domain import Datacenter
 from hcloud.locations.domain import Location
 
 from cloudproxy.providers import settings
-from cloudproxy.providers.config import set_auth
+from cloudproxy.providers.config import set_proxy
 
 client = Client(token=settings.config["providers"]["hetzner"]["secrets"]["access_token"])
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 
 def create_proxy():
-    user_data = set_auth(
-        settings.config["auth"]["username"], settings.config["auth"]["password"], settings.config["auth"]["allowed_ip"]
+    user_data = set_proxy(
+        settings.config["auth"]["username"],
+        settings.config["auth"]["password"],
+        settings.config["auth"]["allowed_ip"],
+        settings.config["proxy_stealth"]
     )
     client.servers.create(name=str(uuid.uuid1()),
                           server_type=ServerType("cx11"),

--- a/cloudproxy/providers/manager.py
+++ b/cloudproxy/providers/manager.py
@@ -31,19 +31,19 @@ def hetzner_manager():
 def init_schedule():
     sched = BackgroundScheduler()
     sched.start()
-    if settings.config["providers"]["digitalocean"]["enabled"] == 'True':
+    if settings.config["providers"]["digitalocean"]["enabled"]:
         sched.add_job(do_manager, "interval", seconds=20)
     else:
         logger.info("DigitalOcean not enabled")
-    if settings.config["providers"]["aws"]["enabled"] == 'True':
+    if settings.config["providers"]["aws"]["enabled"]:
         sched.add_job(aws_manager, "interval", seconds=20)
     else:
         logger.info("AWS not enabled")
-    if settings.config["providers"]["gcp"]["enabled"] == 'True':
+    if settings.config["providers"]["gcp"]["enabled"]:
         sched.add_job(gcp_manager, "interval", seconds=20)
     else:
         logger.info("GCP not enabled")
-    if settings.config["providers"]["hetzner"]["enabled"] == 'True':
+    if settings.config["providers"]["hetzner"]["enabled"]:
         sched.add_job(hetzner_manager, "interval", seconds=20)
     else:
         logger.info("Hetzner not enabled")

--- a/cloudproxy/providers/scaleway/functions.py
+++ b/cloudproxy/providers/scaleway/functions.py
@@ -1,7 +1,7 @@
 import uuid as uuid
 import json
 from cloudproxy.providers import settings
-from cloudproxy.providers.config import set_auth
+from cloudproxy.providers.config import set_proxy
 from scaleway.apis import ComputeAPI
 from slumber.exceptions import HttpClientError
 
@@ -11,7 +11,7 @@ compute_api = ComputeAPI(
 
 
 def create_proxy():
-    user_data = set_auth(
+    user_data = set_proxy(
         settings.config["auth"]["username"], settings.config["auth"]["password"], settings.config["auth"]["allowed_ip"]
     )
     # try:

--- a/cloudproxy/providers/scaleway/functions.py
+++ b/cloudproxy/providers/scaleway/functions.py
@@ -12,7 +12,7 @@ compute_api = ComputeAPI(
 
 def create_proxy():
     user_data = set_auth(
-        settings.config["auth"]["username"], settings.config["auth"]["password"]
+        settings.config["auth"]["username"], settings.config["auth"]["password"], settings.config["auth"]["allowed_ip"]
     )
     # try:
     #     res = compute_api.query().images.get()

--- a/cloudproxy/providers/scaleway/functions.py
+++ b/cloudproxy/providers/scaleway/functions.py
@@ -12,7 +12,10 @@ compute_api = ComputeAPI(
 
 def create_proxy():
     user_data = set_proxy(
-        settings.config["auth"]["username"], settings.config["auth"]["password"], settings.config["auth"]["allowed_ip"]
+        settings.config["auth"]["username"],
+        settings.config["auth"]["password"],
+        settings.config["auth"]["allowed_ip"],
+        settings.config["proxy_stealth"]
     )
     # try:
     #     res = compute_api.query().images.get()

--- a/cloudproxy/providers/settings.py
+++ b/cloudproxy/providers/settings.py
@@ -54,6 +54,7 @@ load_dotenv()
 # Set proxy authentication
 config["auth"]["username"] = os.environ.get("USERNAME", "changeme")
 config["auth"]["password"] = os.environ.get("PASSWORD", "changeme")
+config["auth"]["allowed_ip"] = os.environ.get("ALLOWED_IP", "")
 config["age_limit"] = int(os.environ.get('AGE_LIMIT', 0))
 
 # Set DigitalOcean config

--- a/cloudproxy/providers/settings.py
+++ b/cloudproxy/providers/settings.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 
 config = {
     "auth": {"username": "", "password": "", "allowed_ip": ""},
+    "proxy_stealth": False,
     "age_limit": 0,
     "providers": {
         "digitalocean": {
@@ -57,6 +58,9 @@ config["auth"]["username"] = os.environ.get("USERNAME", "changeme")
 config["auth"]["password"] = os.environ.get("PASSWORD", "changeme")
 config["auth"]["allowed_ip"] = os.environ.get("ALLOWED_IP", "")
 config["age_limit"] = int(os.environ.get('AGE_LIMIT', 0))
+
+# Set proxy behaviour
+config["proxy_stealth"] = os.environ.get("PROXY_STEALTH", False)
 
 # Set DigitalOcean config
 config["providers"]["digitalocean"]["enabled"] = os.environ.get(

--- a/cloudproxy/providers/settings.py
+++ b/cloudproxy/providers/settings.py
@@ -2,7 +2,7 @@ import os
 from dotenv import load_dotenv
 
 config = {
-    "auth": {"username": "", "password": ""},
+    "auth": {"username": "", "password": "", "allowed_ip": ""},
     "age_limit": 0,
     "providers": {
         "digitalocean": {
@@ -14,6 +14,7 @@ config = {
             "secrets": {"access_token": ""},
         },
         "aws": {
+            "allowed_ip": "",
             "enabled": False,
             "ips": [],
             "scaling": {"min_scaling": 0, "max_scaling": 0},
@@ -85,6 +86,7 @@ config["providers"]["aws"]["secrets"]["access_key_id"] = os.environ.get(
 config["providers"]["aws"]["secrets"]["secret_access_key"] = os.environ.get(
     "AWS_SECRET_ACCESS_KEY"
 )
+config["providers"]["aws"]["key_name"] = os.environ.get("AWS_KEY_NAME", "")
 config["providers"]["aws"]["scaling"]["min_scaling"] = int(
     os.environ.get("AWS_MIN_SCALING", 2)
 )

--- a/cloudproxy/providers/user_data.sh
+++ b/cloudproxy/providers/user_data.sh
@@ -4,7 +4,7 @@ sudo apt-get install -y ca-certificates tinyproxy
 sudo sed -i 's/Port 8888/Port 8899/g' /etc/tinyproxy/tinyproxy.conf
 sudo sed -i 's/Allow 127.0.0.1/#Allow 127.0.0.1/g' /etc/tinyproxy/tinyproxy.conf
 sudo sed -i 's/#BasicAuth user pass.*/BasicAuth username password/g' /etc/tinyproxy/tinyproxy.conf
-sudo sed -i 's/#DisableViaHeader Yes/DisableViaHeader Yes/g' /etc/tinyproxy/tinyproxy.conf
+sudo sed -i 's/#DisableViaHeader Yes/DisableViaHeader No/g' /etc/tinyproxy/tinyproxy.conf
 sudo systemctl restart tinyproxy
 sudo ufw default deny incoming
 sudo ufw allow 22/tcp

--- a/cloudproxy/providers/user_data.sh
+++ b/cloudproxy/providers/user_data.sh
@@ -4,6 +4,7 @@ sudo apt-get install -y ca-certificates tinyproxy
 sudo sed -i 's/Port 8888/Port 8899/g' /etc/tinyproxy/tinyproxy.conf
 sudo sed -i 's/Allow 127.0.0.1/#Allow 127.0.0.1/g' /etc/tinyproxy/tinyproxy.conf
 sudo sed -i 's/#BasicAuth user pass.*/BasicAuth username password/g' /etc/tinyproxy/tinyproxy.conf
+sudo sed -i 's/#DisableViaHeader Yes/DisableViaHeader Yes/g' /etc/tinyproxy/tinyproxy.conf
 sudo systemctl restart tinyproxy
 sudo ufw default deny incoming
 sudo ufw allow 22/tcp

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -30,8 +30,10 @@ Now you have your access key and secret access key, you can now use AWS as a pro
 
 ``AWS_SIZE``  - this sets the instance size, we recommend the smallest instance as the volume even a small instance can handle is high. Default value: t2.micro
 
-``AWS_SPOT`` - use this to launch instances as spot instances. The available options are 'persistent' (if you want to be able to restart them) or 'one-time' (if you plan to terminate them). Not all sizes are able to be launched as spot instances. Default value: False
+``AWS_SPOT`` - use this to launch instances as spot instances. The available options are 'persistent' (if you want to be able to restart them) or 'one-time' (if you plan to terminate them). Not all sizes are able to be launched as spot instances. Default value: false
 
 ``AWS_REGION`` - this sets the region where the instance is deployed. Some websites may redirect to the language of the country your IP is from. Default value: eu-west-2
 
 ``AWS_AMI`` - this sets the AMI the instance is deployed with. The default AMI is for Ubuntu 20.04, however each region may use a different AMI ID. If not using eu-west-2, you may need to set a different AMI ID. See the AWS AMI Marketplace for Ubuntu 20.04 AMI IDs. Default value: ami-096cb92bb3580c759
+
+``AWS_KEY_NAME`` - this set a KeyPair to access to the instances.


### PR DESCRIPTION
Actually i'm working with a project with same name called CloudProxy ([https://github.com/NoahCardoza/CloudProxy](https://github.com/NoahCardoza/CloudProxy)). It's to pass throw cloudflare challenge. To do that is using a chrome with pupeeter. It's starting a chrome browser passing a proxy via parameter but it doesn't accept user and password on it ([https://superuser.com/questions/902620/google-chrome-proxy-settings-with-username-and-password](https://superuser.com/questions/902620/google-chrome-proxy-settings-with-username-and-password)).
This is the motivation to fork it and implement an alternative way to authenticate with proxy than using user and password. I used the parameter allowed_ip from tinyproxy.

Implemented:
- Alternatrive authentication using ALLOWED_IP
- Variable environments that are using boolean now are using real boolean instead of String. Instead of using ENABLE_AWS=True now you should write ENABLE_AWS=true. And in code we are using now (if ENABLE_AWS:) instead of (if ENABLE_AWS='True')
- Check if proxy is working we are trying to load google.com throw the proxy instead of check the proxy url directly. For some strange reason proxy server response 403 HTTP forbidden when you visit is directly. Ex: http://10.12.23.3:8899 if it's using allowed_id, but it's really working as proxy. Increased timeout to 6 to let the proxy do its job.
- Added optional parameter AWS_KEY_NAME to pass throw  a pairkey to login on the EC2 instance.
- Added optional parameter PROXY_STEALTH=true, default false to set proxy in stealth mode and not sending proxy headers on its requests to the sites.
- Update README.md and docs/aws.md

Since is the first time i do something on python and docker. Probably is not really optimitzed and i guess there is space to enhance. I tested it on DigitalOcean, Hetzner and AWS and it works flawless without problems atm. 

I published a docker image: bubexel/cloudprroxy:latest

Thank you for your work on it!

Greetings
