### PR TITLE
Remove reload that cancelled the post request

### DIFF
--- a/cloudproxy-ui/src/components/ListProxies.vue
+++ b/cloudproxy-ui/src/components/ListProxies.vue
@@ -29,7 +29,6 @@
             <b-button
               v-on:click="
                 removeProxy(ips);
-                reloadPage();
                 makeToast(ips);
               "
               variant="danger"


### PR DESCRIPTION
Fixes issue #43 - remove button will now work in Firefox.