### PR TITLE
Add SSL config for HTTPS

### DIFF
--- a/cloudproxy/main.py
+++ b/cloudproxy/main.py
@@ -37,7 +37,8 @@ logger.add("cloudproxy.log", rotation="20 MB")
 
 
 def main():
-    run_uvicorn_loguru(uvicorn.Config(app, host="0.0.0.0", port=8000, log_level="info"))
+    run_uvicorn_loguru(uvicorn.Config(app, host="0.0.0.0", port=8000, log_level="info", ssl_keyfile="./key.pem",
+                ssl_certfile="./cert.pem")))
 
 
 def get_ip_list():


### PR DESCRIPTION
I think this will partly solve https://github.com/claffin/cloudproxy/issues/3. 

The `cert.pem` and `key.pem` can be generated with [mkcert](https://github.com/FiloSottile/mkcert)

Tbh I have no idea what I'm doing, any suggestions would be much appreciated. I tested this locally and I have the docker image running on https now.  

Edit: 
I suppose mkcert is only good for https in local environments. My goal is to deploy Cloudproxy to an AWS ec2 instance and make it accessible via HTTPS, and ensure communication between the cloudproxy server and proxy servers are done via HTTPS as well. 