### PR TITLE
Proxy without usr/psw authentication and IP-based auntenthication

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,13 @@ All you need is:
 #### Environment variables:
 
 ##### Required
-- `USERNAME` - set the username for the forward proxy.
-- `PASSWORD` - set the password for the forward proxy.
+You have two available methods of proxy authentication: username and password or IP restriction. You can use either one or both simultaneously.
 
-The username and password should be alphanumeric. Using special characters may cause issues due to how URL encoding works.
+- `USERNAME`, `PASSWORD` - set the username and password for the forward proxy. The username and password should consist of alphanumeric characters. Using special characters may cause issues due to how URL encoding works.
+- `ONLY_HOST_IP` - set this variable to true if you want to restrict access to the proxy only to the host server (i.e., the IP address of the server running the CloudProxy Docker container).
 
 ##### Optional
-
-`` AGE_LIMIT`` - set the age limit for your forward proxies in seconds. Once the age limit is reached, the proxy is replaced. A value of 0 disables the feature. Default value: 0.
+- `AGE_LIMIT` - set the age limit for your forward proxies in seconds. Once the age limit is reached, the proxy is replaced. A value of 0 disables the feature. Default: disabled.
 
 See individual provider pages for environment variables required in above providers supported section.
 
@@ -70,6 +69,7 @@ For example:
    ```shell
    docker run -e USERNAME='CHANGE_THIS_USERNAME' \
        -e PASSWORD='CHANGE_THIS_PASSWORD' \
+       -e ONLY_HOST_IP=True \
        -e DIGITALOCEAN_ENABLED=True \
        -e DIGITALOCEAN_ACCESS_TOKEN='YOUR SECRET ACCESS KEY' \
        -it -p 8000:8000 laffin/cloudproxy:latest

--- a/cloudproxy/check.py
+++ b/cloudproxy/check.py
@@ -25,14 +25,21 @@ def requests_retry_session(
 
 
 def fetch_ip(ip_address):
-    auth = (
-        settings.config["auth"]["username"] + ":" + settings.config["auth"]["password"]
-    )
+    if settings.config["no_auth"]:
+        proxies = {
+            "http": "http://" + ip_address + ":8899",
+            "https": "http://" + ip_address + ":8899",
+        }
+    else:
+        auth = (
+            settings.config["auth"]["username"] + ":" + settings.config["auth"]["password"]
+        )
 
-    proxies = {
-        "http": "http://" + auth + "@" + ip_address + ":8899",
-        "https": "http://" + auth + "@" + ip_address + ":8899",
-    }
+        proxies = {
+            "http": "http://" + auth + "@" + ip_address + ":8899",
+            "https": "http://" + auth + "@" + ip_address + ":8899",
+        }
+    
     s = requests.Session()
     s.proxies = proxies
 
@@ -44,7 +51,7 @@ def fetch_ip(ip_address):
 
 def check_alive(ip_address):
     try:
-        result = requests.get("http://" + ip_address + ":8899", timeout=3)
+        result = requests.get("http://ipecho.net/plain", proxies={'http': "http://" + ip_address + ":8899"}, timeout=3)
         if result.status_code in (200, 407):
             return True
         else:

--- a/cloudproxy/main.py
+++ b/cloudproxy/main.py
@@ -46,15 +46,18 @@ def get_ip_list():
         if settings.config["providers"][provider]["ips"]:
             for ip in settings.config["providers"][provider]["ips"]:
                 if ip not in delete_queue and ip not in restart_queue:
-                    ip_list.append(
-                        "http://"
-                        + settings.config["auth"]["username"]
-                        + ":"
-                        + settings.config["auth"]["password"]
-                        + "@"
-                        + ip
-                        + ":8899"
-                    )
+                    if settings.config["no_auth"]:
+                        ip_list.append("http://" + ip + ":8899")
+                    else:
+                        ip_list.append(
+                            "http://"
+                            + settings.config["auth"]["username"]
+                            + ":"
+                            + settings.config["auth"]["password"]
+                            + "@"
+                            + ip
+                            + ":8899"
+                        )
     return ip_list
 
 

--- a/cloudproxy/providers/config.py
+++ b/cloudproxy/providers/config.py
@@ -1,12 +1,25 @@
 import os
+import requests
+from cloudproxy.providers import settings
 
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 
 def set_auth(username, password):
+    
     with open(os.path.join(__location__, "user_data.sh")) as file:
         filedata = file.read()
+
+    if settings.config["no_auth"]:
+        filedata = filedata.replace("\nsudo sed -i 's/#BasicAuth user pass.*/BasicAuth username password/g' /etc/tinyproxy/tinyproxy.conf", "")
+    else:
         filedata = filedata.replace("username", username)
         filedata = filedata.replace("password", password)
+
+    if settings.config["only_host_ip"]:
+        ip_address = requests.get('https://ipecho.net/plain').text.strip()
+        filedata = filedata.replace("ufw allow 22/tcp", f"sudo ufw allow from {ip_address} to any port 22 proto tcp")
+        filedata = filedata.replace("ufw allow 8899/tcp", f"sudo ufw allow from {ip_address} to any port 8899 proto tcp")
+
     return filedata

--- a/cloudproxy/providers/settings.py
+++ b/cloudproxy/providers/settings.py
@@ -3,6 +3,8 @@ from dotenv import load_dotenv
 
 config = {
     "auth": {"username": "", "password": ""},
+    "no_auth": False,
+    "only_host_ip": False,
     "age_limit": 0,
     "providers": {
         "digitalocean": {
@@ -55,6 +57,8 @@ load_dotenv()
 config["auth"]["username"] = os.environ.get("USERNAME", "changeme")
 config["auth"]["password"] = os.environ.get("PASSWORD", "changeme")
 config["age_limit"] = int(os.environ.get('AGE_LIMIT', 0))
+config["no_auth"] = config["auth"]["username"] == "changeme" and config["auth"]["password"] == "changeme"
+config["only_host_ip"] = os.environ.get("ONLY_HOST_IP", False)
 
 # Set DigitalOcean config
 config["providers"]["digitalocean"]["enabled"] = os.environ.get(

--- a/tests/test_providers_digitalocean_config.py
+++ b/tests/test_providers_digitalocean_config.py
@@ -1,6 +1,7 @@
 import os
 
 from cloudproxy.providers.config import set_auth
+from cloudproxy.providers import settings
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
@@ -8,4 +9,6 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 def test_set_auth():
     with open(os.path.join(__location__, 'test_user_data.sh')) as file:
         filedata = file.read()
+    settings.config["no_auth"] = False
     assert set_auth("testingusername", "testinguserpassword") == filedata
+    


### PR DESCRIPTION
Chromium based solutions [do not support user/password proxy authentication](https://chromium.googlesource.com/chromium/src/+/HEAD/net/docs/proxy.md#proxy-credentials-in-manual-proxy-settings) and given the fact that it is outdated/unsecure option it will rather not change in future. To bypass this, this request:
- supports setting up proxies without username and password,
- adds additional authentication method - ONLY_HOST_IP - to avoid leaving proxy without any security.

No breaking changes, although I don't know why in case of proxies without username and password this check_alive directly reaching to proxy fails:
`result = requests.get("http://" + ip_address + ":8899", timeout=3)`
and returns this error (after removing timeout restriction):
`Unable to connect
Tinyproxy was unable to connect to the remote web server.
Generated by [tinyproxy](https://tinyproxy.github.io/) version 1.11.0.`
However, using the very same IP as a proxy works without issues, hence I updated the line to:
`result = requests.get("http://ipecho.net/plain", proxies={'http': "http://" + ip_address + ":8899"}, timeout=3)`.