### PR TITLE
Add multi-account support for cloud providers

### DIFF
--- a/cloudproxy/check.py
+++ b/cloudproxy/check.py
@@ -51,7 +51,7 @@ def fetch_ip(ip_address):
 
 def check_alive(ip_address):
     try:
-        result = requests.get("http://ipecho.net/plain", proxies={'http': "http://" + ip_address + ":8899"}, timeout=3)
+        result = requests.get("http://ipecho.net/plain", proxies={'http': "http://" + ip_address + ":8899"}, timeout=10)
         if result.status_code in (200, 407):
             return True
         else:

--- a/cloudproxy/providers/aws/functions.py
+++ b/cloudproxy/providers/aws/functions.py
@@ -9,19 +9,112 @@ from cloudproxy.providers.settings import config
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
-ec2 = boto3.resource("ec2", region_name=config["providers"]["aws"]["region"])
-ec2_client = boto3.client("ec2", region_name=config["providers"]["aws"]["region"])
-tags = [
-    {"Key": "cloudproxy", "Value": "cloudproxy"},
-    {"Key": "Name", "Value": "CloudProxy-Instance"}
-]
-tag_specification = [
-    {"ResourceType": "instance", "Tags": tags},
-]
+# Module-level variables needed for tests
+ec2 = None
+ec2_client = None
+
+def reset_clients():
+    """
+    Reset the module-level client variables.
+    This is primarily used in tests to ensure a clean state.
+    """
+    global ec2, ec2_client
+    ec2 = None
+    ec2_client = None
+
+def get_clients(instance_config=None):
+    """
+    Initialize and return AWS clients based on the provided configuration.
+    
+    Args:
+        instance_config: The specific instance configuration
+        
+    Returns:
+        tuple: (ec2_resource, ec2_client)
+    """
+    # Use global variables to allow mocking in tests
+    global ec2, ec2_client
+    
+    # If clients are already set (likely by a test), return them
+    if ec2 is not None and ec2_client is not None:
+        return ec2, ec2_client
+        
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+    
+    # Get AWS credentials from the instance configuration
+    aws_access_key_id = instance_config["secrets"]["access_key_id"]
+    aws_secret_access_key = instance_config["secrets"]["secret_access_key"]
+    region_name = instance_config["region"]
+    
+    # Create AWS clients using the instance-specific credentials
+    ec2 = boto3.resource(
+        "ec2", 
+        region_name=region_name,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key
+    )
+    
+    ec2_client = boto3.client(
+        "ec2", 
+        region_name=region_name,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key
+    )
+    
+    return ec2, ec2_client
+
+def get_tags(instance_config=None):
+    """
+    Get tags for AWS resources based on the provided configuration.
+    
+    Args:
+        instance_config: The specific instance configuration
+        
+    Returns:
+        tuple: (tags, tag_specification)
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+    
+    # Use instance name in the tag if available
+    instance_name = instance_config.get("display_name", "default")
+    instance_id = next(
+        (name for name, inst in config["providers"]["aws"]["instances"].items() 
+         if inst == instance_config), 
+        "default"
+    )
+    
+    tags = [
+        {"Key": "cloudproxy", "Value": "cloudproxy"},
+        {"Key": "cloudproxy-instance", "Value": instance_id},
+        {"Key": "Name", "Value": f"CloudProxy-{instance_name}"}
+    ]
+    
+    tag_specification = [
+        {"ResourceType": "instance", "Tags": tags},
+    ]
+    
+    return tags, tag_specification
 
 
-def create_proxy():
+def create_proxy(instance_config=None):
+    """
+    Create an AWS proxy instance.
+    
+    Args:
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+    
+    # Get clients and tags
+    ec2, ec2_client = get_clients(instance_config)
+    tags, tag_specification = get_tags(instance_config)
+    
+    # Find default VPC
     vpcs = list((ec2.vpcs.filter()))
+    default_vpc = None
     for vpc in vpcs:
         response = ec2_client.describe_vpcs(
             VpcIds=[
@@ -31,10 +124,16 @@ def create_proxy():
 
         if response["Vpcs"][0]["IsDefault"]:
             default_vpc = response["Vpcs"][0]["VpcId"]
+    
+    # Setup user data with appropriate authentication
     user_data = set_auth(config["auth"]["username"], config["auth"]["password"])
+    
+    # Create security group if needed
     try:
         sg = ec2.create_security_group(
-            Description="SG for CloudProxy", GroupName="cloudproxy", VpcId=default_vpc
+            Description=f"SG for CloudProxy {instance_config.get('display_name', 'default')}",
+            GroupName=f"cloudproxy-{next((name for name, inst in config['providers']['aws']['instances'].items() if inst == instance_config), 'default')}",
+            VpcId=default_vpc
         )
         sg.authorize_ingress(
             CidrIp="0.0.0.0/0", IpProtocol="tcp", FromPort=8899, ToPort=8899
@@ -44,14 +143,18 @@ def create_proxy():
         )
     except botocore.exceptions.ClientError:
         pass
-    sg_id = ec2_client.describe_security_groups(GroupNames=["cloudproxy"])
+    
+    # Get security group ID
+    sg_id = ec2_client.describe_security_groups(GroupNames=[f"cloudproxy-{next((name for name, inst in config['providers']['aws']['instances'].items() if inst == instance_config), 'default')}"])
     sg_id = sg_id["SecurityGroups"][0]["GroupId"]
-    if config["providers"]["aws"]["spot"] == 'persistent':
+    
+    # Create instance with appropriate spot configuration
+    if instance_config["spot"] == 'persistent':
         instance = ec2.create_instances(
-            ImageId=config["providers"]["aws"]["ami"],
+            ImageId=instance_config["ami"],
             MinCount=1,
             MaxCount=1,
-            InstanceType=config["providers"]["aws"]["size"],
+            InstanceType=instance_config["size"],
             NetworkInterfaces=[
                 {"DeviceIndex": 0, "AssociatePublicIpAddress": True, "Groups": [sg_id]}
             ],
@@ -65,12 +168,12 @@ def create_proxy():
             TagSpecifications=tag_specification,
             UserData=user_data,
         )
-    elif config["providers"]["aws"]["spot"] == 'one-time':
+    elif instance_config["spot"] == 'one-time':
             instance = ec2.create_instances(
-                ImageId=config["providers"]["aws"]["ami"],
+                ImageId=instance_config["ami"],
                 MinCount=1,
                 MaxCount=1,
-                InstanceType=config["providers"]["aws"]["size"],
+                InstanceType=instance_config["size"],
                 NetworkInterfaces=[
                     {"DeviceIndex": 0, "AssociatePublicIpAddress": True, "Groups": [sg_id]}
                 ],
@@ -86,10 +189,10 @@ def create_proxy():
             )
     else:
         instance = ec2.create_instances(
-            ImageId=config["providers"]["aws"]["ami"],
+            ImageId=instance_config["ami"],
             MinCount=1,
             MaxCount=1,
-            InstanceType=config["providers"]["aws"]["size"],
+            InstanceType=instance_config["size"],
             NetworkInterfaces=[
                 {"DeviceIndex": 0, "AssociatePublicIpAddress": True, "Groups": [sg_id]}
             ],
@@ -99,10 +202,23 @@ def create_proxy():
     return instance
 
 
-def delete_proxy(instance_id):
+def delete_proxy(instance_id, instance_config=None):
+    """
+    Delete an AWS proxy instance.
+    
+    Args:
+        instance_id: ID of the instance to delete
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+    
+    # Get clients
+    ec2, ec2_client = get_clients(instance_config)
+    
     ids = [instance_id]
     deleted = ec2.instances.filter(InstanceIds=ids).terminate()
-    if config["providers"]["aws"]["spot"]:
+    if instance_config["spot"]:
         associated_spot_instance_requests = ec2_client.describe_spot_instance_requests(
             Filters=[
                 {
@@ -119,13 +235,39 @@ def delete_proxy(instance_id):
     return deleted
 
 
-def stop_proxy(instance_id):
+def stop_proxy(instance_id, instance_config=None):
+    """
+    Stop an AWS proxy instance.
+    
+    Args:
+        instance_id: ID of the instance to stop
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+    
+    # Get clients
+    ec2, ec2_client = get_clients(instance_config)
+    
     ids = [instance_id]
     stopped = ec2.instances.filter(InstanceIds=ids).stop()
     return stopped
 
 
-def start_proxy(instance_id):
+def start_proxy(instance_id, instance_config=None):
+    """
+    Start an AWS proxy instance.
+    
+    Args:
+        instance_id: ID of the instance to start
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+    
+    # Get clients
+    ec2, ec2_client = get_clients(instance_config)
+    
     ids = [instance_id]
     try:
         started = ec2.instances.filter(InstanceIds=ids).start()
@@ -137,10 +279,70 @@ def start_proxy(instance_id):
     return started
 
 
-def list_instances():
+def list_instances(instance_config=None):
+    """
+    List AWS proxy instances.
+    
+    Args:
+        instance_config: The specific instance configuration
+        
+    Returns:
+        list: List of AWS instances
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+    
+    # Get clients
+    ec2, ec2_client = get_clients(instance_config)
+    
+    # Get instance ID for this configuration
+    instance_id = next(
+        (name for name, inst in config["providers"]["aws"]["instances"].items() 
+         if inst == instance_config), 
+        "default"
+    )
+    
+    # Filter instances for this specific instance
     filters = [
         {"Name": "tag:cloudproxy", "Values": ["cloudproxy"]},
+        {"Name": "tag:cloudproxy-instance", "Values": [instance_id]},
         {"Name": "instance-state-name", "Values": ["pending", "running", "stopped", "stopping"]},
     ]
     instances = ec2_client.describe_instances(Filters=filters)
-    return instances["Reservations"]
+    result = instances["Reservations"]
+    
+    # If this is the default instance, also find instances created before multi-instance support
+    if instance_id == "default":
+        # Get all cloudproxy instances without filtering by instance tag
+        base_filters = [
+            {"Name": "tag:cloudproxy", "Values": ["cloudproxy"]},
+            {"Name": "instance-state-name", "Values": ["pending", "running", "stopped", "stopping"]},
+        ]
+        all_instances = ec2_client.describe_instances(Filters=base_filters)
+        
+        # Track IDs we already have in our result
+        existing_ids = set()
+        for reservation in result:
+            for instance in reservation["Instances"]:
+                existing_ids.add(instance["InstanceId"])
+        
+        # Add instances that don't have the cloudproxy-instance tag at all
+        for reservation in all_instances["Reservations"]:
+            for instance in reservation["Instances"]:
+                # Skip if we already have this instance
+                if instance["InstanceId"] in existing_ids:
+                    continue
+                
+                # Check if this instance has any cloudproxy-instance tag
+                has_instance_tag = False
+                for tag in instance.get("Tags", []):
+                    if tag["Key"] == "cloudproxy-instance":
+                        has_instance_tag = True
+                        break
+                
+                # If no instance tag, add this reservation to our results
+                if not has_instance_tag:
+                    result.append(reservation)
+                    existing_ids.add(instance["InstanceId"])
+    
+    return result

--- a/cloudproxy/providers/aws/main.py
+++ b/cloudproxy/providers/aws/main.py
@@ -14,107 +14,156 @@ from cloudproxy.providers.aws.functions import (
 from cloudproxy.providers.settings import delete_queue, restart_queue, config
 
 
-def aws_deployment(min_scaling):
-    total_instances = len(list_instances())
+def aws_deployment(min_scaling, instance_config=None):
+    """
+    Deploy AWS instances based on min_scaling requirements.
+    
+    Args:
+        min_scaling: The minimum number of instances to maintain
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+        
+    total_instances = len(list_instances(instance_config))
     if min_scaling < total_instances:
-        logger.info("Overprovisioned: AWS destroying.....")
+        logger.info(f"Overprovisioned: AWS {instance_config.get('display_name', 'default')} destroying.....")
         for instance in itertools.islice(
-            list_instances(), 0, (total_instances - min_scaling)
+            list_instances(instance_config), 0, (total_instances - min_scaling)
         ):
-            delete_proxy(instance["Instances"][0]["InstanceId"])
+            delete_proxy(instance["Instances"][0]["InstanceId"], instance_config)
             try:
                 msg = instance["Instances"][0]["PublicIpAddress"]
             except KeyError:
                 msg = instance["Instances"][0]["InstanceId"]
 
-            logger.info("Destroyed: AWS -> " + msg)
+            logger.info(f"Destroyed: AWS {instance_config.get('display_name', 'default')} -> " + msg)
     if min_scaling - total_instances < 1:
-        logger.info("Minimum AWS instances met")
+        logger.info(f"Minimum AWS {instance_config.get('display_name', 'default')} instances met")
     else:
         total_deploy = min_scaling - total_instances
-        logger.info("Deploying: " + str(total_deploy) + " AWS instances")
+        logger.info(f"Deploying: {str(total_deploy)} AWS {instance_config.get('display_name', 'default')} instances")
         for _ in range(total_deploy):
-            create_proxy()
-            logger.info("Deployed")
-    return len(list_instances())
+            create_proxy(instance_config)
+            logger.info(f"Deployed AWS {instance_config.get('display_name', 'default')} instance")
+    return len(list_instances(instance_config))
 
 
-def aws_check_alive():
+def aws_check_alive(instance_config=None):
+    """
+    Check if AWS instances are alive and operational.
+    
+    Args:
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+        
     ip_ready = []
-    for instance in list_instances():
+    for instance in list_instances(instance_config):
         try:
             elapsed = datetime.datetime.now(
                 datetime.timezone.utc
             ) - instance["Instances"][0]["LaunchTime"]
             if config["age_limit"] > 0 and elapsed > datetime.timedelta(seconds=config["age_limit"]):
-                delete_proxy(instance["Instances"][0]["InstanceId"])
+                delete_proxy(instance["Instances"][0]["InstanceId"], instance_config)
                 logger.info(
-                    "Recycling droplet, reached age limit -> " + instance["Instances"][0]["PublicIpAddress"]
+                    f"Recycling AWS {instance_config.get('display_name', 'default')} instance, reached age limit -> " + instance["Instances"][0]["PublicIpAddress"]
                 )
             elif instance["Instances"][0]["State"]["Name"] == "stopped":
                 logger.info(
-                    "Waking up: AWS -> Instance " + instance["Instances"][0]["InstanceId"]
+                    f"Waking up: AWS {instance_config.get('display_name', 'default')} -> Instance " + instance["Instances"][0]["InstanceId"]
                 )
-                started = start_proxy(instance["Instances"][0]["InstanceId"])
+                started = start_proxy(instance["Instances"][0]["InstanceId"], instance_config)
                 if not started:
                     logger.info(
                         "Could not wake up due to IncorrectSpotRequestState, trying again later."
                     )
             elif instance["Instances"][0]["State"]["Name"] == "stopping":
                 logger.info(
-                    "Stopping: AWS -> " + instance["Instances"][0]["PublicIpAddress"]
+                    f"Stopping: AWS {instance_config.get('display_name', 'default')} -> " + instance["Instances"][0]["PublicIpAddress"]
                 )
             elif instance["Instances"][0]["State"]["Name"] == "pending":
                 logger.info(
-                    "Pending: AWS -> " + instance["Instances"][0]["PublicIpAddress"]
+                    f"Pending: AWS {instance_config.get('display_name', 'default')} -> " + instance["Instances"][0]["PublicIpAddress"]
                 )
             # Must be "pending" if none of the above, check if alive or not.
             elif check_alive(instance["Instances"][0]["PublicIpAddress"]):
                 logger.info(
-                    "Alive: AWS -> " + instance["Instances"][0]["PublicIpAddress"]
+                    f"Alive: AWS {instance_config.get('display_name', 'default')} -> " + instance["Instances"][0]["PublicIpAddress"]
                 )
                 ip_ready.append(instance["Instances"][0]["PublicIpAddress"])
             else:
                 if elapsed > datetime.timedelta(minutes=10):
-                    delete_proxy(instance["Instances"][0]["InstanceId"])
+                    delete_proxy(instance["Instances"][0]["InstanceId"], instance_config)
                     logger.info(
-                        "Destroyed: took too long AWS -> "
+                        f"Destroyed: took too long AWS {instance_config.get('display_name', 'default')} -> "
                         + instance["Instances"][0]["PublicIpAddress"]
                     )
                 else:
                     logger.info(
-                        "Waiting: AWS -> " + instance["Instances"][0]["PublicIpAddress"]
+                        f"Waiting: AWS {instance_config.get('display_name', 'default')} -> " + instance["Instances"][0]["PublicIpAddress"]
                     )
         except (TypeError, KeyError):
-            logger.info("Pending: AWS -> allocating ip")
+            logger.info(f"Pending: AWS {instance_config.get('display_name', 'default')} -> allocating ip")
     return ip_ready
 
 
-def aws_check_delete():
-    for instance in list_instances():
+def aws_check_delete(instance_config=None):
+    """
+    Check if any AWS instances need to be deleted.
+    
+    Args:
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+        
+    for instance in list_instances(instance_config):
         if instance["Instances"][0].get("PublicIpAddress") in delete_queue:
-            delete_proxy(instance["Instances"][0]["InstanceId"])
+            delete_proxy(instance["Instances"][0]["InstanceId"], instance_config)
             logger.info(
-                "Destroyed: not wanted -> "
+                f"Destroyed: not wanted AWS {instance_config.get('display_name', 'default')} -> "
                 + instance["Instances"][0]["PublicIpAddress"]
             )
             delete_queue.remove(instance["Instances"][0]["PublicIpAddress"])
 
 
-def aws_check_stop():
-    for instance in list_instances():
+def aws_check_stop(instance_config=None):
+    """
+    Check if any AWS instances need to be stopped.
+    
+    Args:
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+        
+    for instance in list_instances(instance_config):
         if instance["Instances"][0].get("PublicIpAddress") in restart_queue:
-            stop_proxy(instance["Instances"][0]["InstanceId"])
+            stop_proxy(instance["Instances"][0]["InstanceId"], instance_config)
             logger.info(
-                "Stopped: getting new IP -> "
+                f"Stopped: getting new IP AWS {instance_config.get('display_name', 'default')} -> "
                 + instance["Instances"][0]["PublicIpAddress"]
             )
             restart_queue.remove(instance["Instances"][0]["PublicIpAddress"])
 
 
-def aws_start():
-    aws_check_delete()
-    aws_check_stop()
-    aws_deployment(config["providers"]["aws"]["scaling"]["min_scaling"])
-    ip_ready = aws_check_alive()
+def aws_start(instance_config=None):
+    """
+    Start the AWS provider lifecycle.
+    
+    Args:
+        instance_config: The specific instance configuration
+    
+    Returns:
+        list: List of ready IP addresses
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["aws"]["instances"]["default"]
+        
+    aws_check_delete(instance_config)
+    aws_check_stop(instance_config)
+    aws_deployment(instance_config["scaling"]["min_scaling"], instance_config)
+    ip_ready = aws_check_alive(instance_config)
     return ip_ready

--- a/cloudproxy/providers/digitalocean/main.py
+++ b/cloudproxy/providers/digitalocean/main.py
@@ -16,75 +16,143 @@ from cloudproxy.providers import settings
 from cloudproxy.providers.settings import delete_queue, restart_queue, config
 
 
-def do_deployment(min_scaling):
-    total_droplets = len(list_droplets())
+def do_deployment(min_scaling, instance_config=None):
+    """
+    Deploy DigitalOcean droplets based on min_scaling requirements.
+    
+    Args:
+        min_scaling: The minimum number of droplets to maintain
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["digitalocean"]["instances"]["default"]
+        
+    # Get instance display name for logging
+    display_name = instance_config.get("display_name", "default")
+    
+    total_droplets = len(list_droplets(instance_config))
     if min_scaling < total_droplets:
-        logger.info("Overprovisioned: DO destroying.....")
-        for droplet in itertools.islice(list_droplets(), 0, (total_droplets - min_scaling)):
-            delete_proxy(droplet)
-            logger.info("Destroyed: DO -> " + str(droplet.ip_address))
+        logger.info(f"Overprovisioned: DO {display_name} destroying.....")
+        for droplet in itertools.islice(list_droplets(instance_config), 0, (total_droplets - min_scaling)):
+            delete_proxy(droplet, instance_config)
+            logger.info(f"Destroyed: DO {display_name} -> {str(droplet.ip_address)}")
             
     if min_scaling - total_droplets < 1:
-        logger.info("Minimum DO Droplets met")
+        logger.info(f"Minimum DO {display_name} Droplets met")
     else:
         total_deploy = min_scaling - total_droplets
-        logger.info("Deploying: " + str(total_deploy) + " DO droplets")
+        logger.info(f"Deploying: {str(total_deploy)} DO {display_name} droplets")
         for _ in range(total_deploy):
-            create_proxy()
-            logger.info("Deployed")
-    return len(list_droplets())
+            create_proxy(instance_config)
+            logger.info(f"Deployed DO {display_name} droplet")
+    return len(list_droplets(instance_config))
 
 
-def do_check_alive():
+def do_check_alive(instance_config=None):
+    """
+    Check if DigitalOcean droplets are alive and operational.
+    
+    Args:
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["digitalocean"]["instances"]["default"]
+        
+    # Get instance display name for logging
+    display_name = instance_config.get("display_name", "default")
+    
     ip_ready = []
-    for droplet in list_droplets():
+    for droplet in list_droplets(instance_config):
         try:
             elapsed = datetime.datetime.now(
                 datetime.timezone.utc
             ) - dateparser.parse(droplet.created_at)
             if config["age_limit"] > 0 and elapsed > datetime.timedelta(seconds=config["age_limit"]):
-                delete_proxy(droplet)
+                delete_proxy(droplet, instance_config)
                 logger.info(
-                    "Recycling droplet, reached age limit -> " + str(droplet.ip_address)
+                    f"Recycling DO {display_name} droplet, reached age limit -> {str(droplet.ip_address)}"
                 )
             elif check_alive(droplet.ip_address):
-                logger.info("Alive: DO -> " + str(droplet.ip_address))
+                logger.info(f"Alive: DO {display_name} -> {str(droplet.ip_address)}")
                 ip_ready.append(droplet.ip_address)
             else:
                 if elapsed > datetime.timedelta(minutes=10):
-                    delete_proxy(droplet)
+                    delete_proxy(droplet, instance_config)
                     logger.info(
-                        "Destroyed: took too long DO -> " + str(droplet.ip_address)
+                        f"Destroyed: took too long DO {display_name} -> {str(droplet.ip_address)}"
                     )
                 else:
-                    logger.info("Waiting: DO -> " + str(droplet.ip_address))
+                    logger.info(f"Waiting: DO {display_name} -> {str(droplet.ip_address)}")
         except TypeError:
-            logger.info("Pending: DO allocating")
+            logger.info(f"Pending: DO {display_name} allocating")
     return ip_ready
 
 
-def do_check_delete():
-    for droplet in list_droplets():
+def do_check_delete(instance_config=None):
+    """
+    Check if any DigitalOcean droplets need to be deleted.
+    
+    Args:
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["digitalocean"]["instances"]["default"]
+        
+    # Get instance display name for logging
+    display_name = instance_config.get("display_name", "default")
+    
+    for droplet in list_droplets(instance_config):
         if droplet.ip_address in delete_queue or droplet.ip_address in restart_queue:
-            delete_proxy(droplet)
-            logger.info("Destroyed: not wanted -> " + str(droplet.ip_address))
-            delete_queue.remove(droplet.ip_address)
+            delete_proxy(droplet, instance_config)
+            logger.info(f"Destroyed: not wanted DO {display_name} -> {str(droplet.ip_address)}")
+            if droplet.ip_address in delete_queue:
+                delete_queue.remove(droplet.ip_address)
+            if droplet.ip_address in restart_queue:
+                restart_queue.remove(droplet.ip_address)
 
-def do_fw():
+def do_fw(instance_config=None):
+    """
+    Create a DigitalOcean firewall for proxy droplets.
+    
+    Args:
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["digitalocean"]["instances"]["default"]
+        
+    # Get instance name for logging
+    instance_id = next(
+        (name for name, inst in config["providers"]["digitalocean"]["instances"].items() 
+         if inst == instance_config), 
+        "default"
+    )
+    
     try:
-        create_firewall()
-        logger.info("Created firewall 'cloudproxy'")
+        create_firewall(instance_config)
+        logger.info(f"Created firewall 'cloudproxy-{instance_id}'")
     except DOFirewallExistsException as e:
         pass
     except Exception as e:
         logger.error(e)
 
-def do_start():
-    do_fw()
-    do_check_delete()
+def do_start(instance_config=None):
+    """
+    Start the DigitalOcean provider lifecycle.
+    
+    Args:
+        instance_config: The specific instance configuration
+    
+    Returns:
+        list: List of ready IP addresses
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["digitalocean"]["instances"]["default"]
+        
+    do_fw(instance_config)
+    do_check_delete(instance_config)
     # First check which droplets are alive
-    ip_ready = do_check_alive()
+    ip_ready = do_check_alive(instance_config)
     # Then handle deployment/scaling based on ready droplets
-    do_deployment(settings.config["providers"]["digitalocean"]["scaling"]["min_scaling"])
+    do_deployment(instance_config["scaling"]["min_scaling"], instance_config)
     # Final check for alive droplets
-    return do_check_alive()
+    return do_check_alive(instance_config)

--- a/cloudproxy/providers/hetzner/functions.py
+++ b/cloudproxy/providers/hetzner/functions.py
@@ -10,28 +10,127 @@ from hcloud.locations.domain import Location
 from cloudproxy.providers import settings
 from cloudproxy.providers.config import set_auth
 
-client = Client(token=settings.config["providers"]["hetzner"]["secrets"]["access_token"])
+# Initialize client with default instance configuration
+client = Client(token=settings.config["providers"]["hetzner"]["instances"]["default"]["secrets"]["access_token"])
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 
-def create_proxy():
-    user_data = set_auth(
-        settings.config["auth"]["username"], settings.config["auth"]["password"]
+def get_client(instance_config=None):
+    """
+    Get a Hetzner client for the specific instance configuration.
+    
+    Args:
+        instance_config: The specific instance configuration
+        
+    Returns:
+        Client: Hetzner client instance for the configuration
+    """
+    if instance_config is None:
+        instance_config = settings.config["providers"]["hetzner"]["instances"]["default"]
+    
+    return Client(token=instance_config["secrets"]["access_token"])
+
+
+def create_proxy(instance_config=None):
+    """
+    Create a Hetzner proxy server.
+    
+    Args:
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = settings.config["providers"]["hetzner"]["instances"]["default"]
+        
+    # Get instance name for labeling
+    instance_id = next(
+        (name for name, inst in settings.config["providers"]["hetzner"]["instances"].items() 
+         if inst == instance_config), 
+        "default"
     )
-    client.servers.create(name=str(uuid.uuid1()),
-                          server_type=ServerType(settings.config["providers"]["hetzner"]["size"]),
-                          image=Image(name="ubuntu-20.04"),
-                          location=Location(name=settings.config["providers"]["hetzner"]["location"]),
-                          # datacenter=Datacenter(name=settings.config["providers"]["hetzner"]["datacenter"]),
-                          user_data=user_data, labels={"cloudproxy": "cloudproxy"})
-    return True
+    
+    # Get instance-specific client
+    hetzner_client = get_client(instance_config)
+    
+    # Prepare user data script
+    user_data = set_auth(settings.config["auth"]["username"], settings.config["auth"]["password"])
+    
+    # Determine location or datacenter parameter
+    datacenter = instance_config.get("datacenter", None)
+    location = instance_config.get("location", None)
+    
+    # Create the server with instance-specific settings
+    response = hetzner_client.servers.create(
+        name=f"cloudproxy-{instance_id}-{str(uuid.uuid4())}",
+        server_type=ServerType(instance_config["size"]),
+        image=Image(name="ubuntu-20.04"),
+        user_data=user_data,
+        datacenter=Datacenter(name=datacenter) if datacenter else None,
+        location=Location(name=location) if location else None,
+        labels={"type": "cloudproxy", "instance": instance_id}
+    )
+    
+    return response
 
 
-def delete_proxy(server):
-    deleted = client.servers.delete(server)
-    return deleted
+def delete_proxy(server_id, instance_config=None):
+    """
+    Delete a Hetzner proxy server.
+    
+    Args:
+        server_id: ID of the server to delete
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = settings.config["providers"]["hetzner"]["instances"]["default"]
+        
+    # Get instance-specific client
+    hetzner_client = get_client(instance_config)
+    
+    # Delete the server
+    server = hetzner_client.servers.get(server_id)
+    response = server.delete()
+    
+    return response
 
 
-def list_proxies():
-    servers = client.servers.get_all(label_selector={"cloudproxy": "cloudproxy"})
+def list_proxies(instance_config=None):
+    """
+    List Hetzner proxy servers.
+    
+    Args:
+        instance_config: The specific instance configuration
+        
+    Returns:
+        list: List of Hetzner servers
+    """
+    if instance_config is None:
+        instance_config = settings.config["providers"]["hetzner"]["instances"]["default"]
+        
+    # Get instance name for filtering
+    instance_id = next(
+        (name for name, inst in settings.config["providers"]["hetzner"]["instances"].items() 
+         if inst == instance_config), 
+        "default"
+    )
+    
+    # Get instance-specific client
+    hetzner_client = get_client(instance_config)
+    
+    # Filter servers by labels
+    label_selector = "type=cloudproxy"
+    if instance_id != "default":
+        label_selector += f",instance={instance_id}"
+        
+    servers = hetzner_client.servers.get_all(label_selector=label_selector)
+    
+    # For default instance, also include servers created before multi-instance support
+    if instance_id == "default":
+        # Get old servers without instance label but with cloudproxy type
+        old_servers = hetzner_client.servers.get_all(label_selector="type=cloudproxy")
+        # Filter out servers that have instance labels
+        old_servers = [s for s in old_servers if "instance" not in s.labels]
+        # Merge lists, avoiding duplicates
+        existing_ids = {s.id for s in servers}
+        servers.extend([s for s in old_servers if s.id not in existing_ids])
+    
     return servers

--- a/cloudproxy/providers/hetzner/main.py
+++ b/cloudproxy/providers/hetzner/main.py
@@ -10,61 +10,115 @@ from cloudproxy.providers.hetzner.functions import list_proxies, delete_proxy, c
 from cloudproxy.providers.settings import config, delete_queue, restart_queue
 
 
-def hetzner_deployment(min_scaling):
-    total_proxies = len(list_proxies())
+def hetzner_deployment(min_scaling, instance_config=None):
+    """
+    Deploy Hetzner servers based on min_scaling requirements.
+    
+    Args:
+        min_scaling: The minimum number of servers to maintain
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["hetzner"]["instances"]["default"]
+        
+    # Get instance display name for logging
+    display_name = instance_config.get("display_name", "default")
+    
+    total_proxies = len(list_proxies(instance_config))
     if min_scaling < total_proxies:
-        logger.info("Overprovisioned: Hetzner destroying.....")
+        logger.info(f"Overprovisioned: Hetzner {display_name} destroying.....")
         for proxy in itertools.islice(
-                list_proxies(), 0, (total_proxies - min_scaling)
+                list_proxies(instance_config), 0, (total_proxies - min_scaling)
         ):
-            delete_proxy(proxy)
-            logger.info("Destroyed: Hetzner -> " + str(proxy.public_net.ipv4.ip))
+            delete_proxy(proxy, instance_config)
+            logger.info(f"Destroyed: Hetzner {display_name} -> {str(proxy.public_net.ipv4.ip)}")
+            
     if min_scaling - total_proxies < 1:
-        logger.info("Minimum Hetzner proxies met")
+        logger.info(f"Minimum Hetzner {display_name} proxies met")
     else:
         total_deploy = min_scaling - total_proxies
-        logger.info("Deploying: " + str(total_deploy) + " Hetzner proxy")
+        logger.info(f"Deploying: {str(total_deploy)} Hetzner {display_name} proxy")
         for _ in range(total_deploy):
-            create_proxy()
-            logger.info("Deployed")
-    return len(list_proxies())
+            create_proxy(instance_config)
+            logger.info(f"Deployed Hetzner {display_name} proxy")
+            
+    return len(list_proxies(instance_config))
 
 
-def hetzner_check_alive():
+def hetzner_check_alive(instance_config=None):
+    """
+    Check if Hetzner servers are alive and operational.
+    
+    Args:
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["hetzner"]["instances"]["default"]
+        
+    # Get instance display name for logging
+    display_name = instance_config.get("display_name", "default")
+    
     ip_ready = []
-    for proxy in list_proxies():
+    for proxy in list_proxies(instance_config):
         elapsed = datetime.datetime.now(
             datetime.timezone.utc
         ) - dateparser.parse(str(proxy.created))
         if config["age_limit"] > 0 and elapsed > datetime.timedelta(seconds=config["age_limit"]):
-            delete_proxy(proxy)
+            delete_proxy(proxy, instance_config)
             logger.info(
-                "Recycling proxy, reached age limit -> " + str(proxy.public_net.ipv4.ip)
+                f"Recycling Hetzner {display_name} proxy, reached age limit -> {str(proxy.public_net.ipv4.ip)}"
             )
         elif check_alive(proxy.public_net.ipv4.ip):
-            logger.info("Alive: Hetzner -> " + str(proxy.public_net.ipv4.ip))
+            logger.info(f"Alive: Hetzner {display_name} -> {str(proxy.public_net.ipv4.ip)}")
             ip_ready.append(proxy.public_net.ipv4.ip)
         else:
             if elapsed > datetime.timedelta(minutes=10):
-                delete_proxy(proxy)
+                delete_proxy(proxy, instance_config)
                 logger.info(
-                    "Destroyed: Hetzner took too long -> " + str(proxy.public_net.ipv4.ip)
+                    f"Destroyed: Hetzner {display_name} took too long -> {str(proxy.public_net.ipv4.ip)}"
                 )
             else:
-                logger.info("Waiting: Hetzner -> " + str(proxy.public_net.ipv4.ip))
+                logger.info(f"Waiting: Hetzner {display_name} -> {str(proxy.public_net.ipv4.ip)}")
     return ip_ready
 
 
-def hetzner_check_delete():
-    for proxy in list_proxies():
+def hetzner_check_delete(instance_config=None):
+    """
+    Check if any Hetzner servers need to be deleted.
+    
+    Args:
+        instance_config: The specific instance configuration
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["hetzner"]["instances"]["default"]
+        
+    # Get instance display name for logging
+    display_name = instance_config.get("display_name", "default")
+    
+    for proxy in list_proxies(instance_config):
         if proxy.public_net.ipv4.ip in delete_queue or proxy.public_net.ipv4.ip in restart_queue:
-            delete_proxy(proxy)
-            logger.info("Destroyed: not wanted -> " + str(proxy.public_net.ipv4.ip))
-            delete_queue.remove(proxy.public_net.ipv4.ip)
+            delete_proxy(proxy, instance_config)
+            logger.info(f"Destroyed: not wanted Hetzner {display_name} -> {str(proxy.public_net.ipv4.ip)}")
+            if proxy.public_net.ipv4.ip in delete_queue:
+                delete_queue.remove(proxy.public_net.ipv4.ip)
+            if proxy.public_net.ipv4.ip in restart_queue:
+                restart_queue.remove(proxy.public_net.ipv4.ip)
 
 
-def hetzner_start():
-    hetzner_check_delete()
-    hetzner_deployment(settings.config["providers"]["hetzner"]["scaling"]["min_scaling"])
-    ip_ready = hetzner_check_alive()
+def hetzner_start(instance_config=None):
+    """
+    Start the Hetzner provider lifecycle.
+    
+    Args:
+        instance_config: The specific instance configuration
+    
+    Returns:
+        list: List of ready IP addresses
+    """
+    if instance_config is None:
+        instance_config = config["providers"]["hetzner"]["instances"]["default"]
+        
+    hetzner_check_delete(instance_config)
+    hetzner_deployment(instance_config["scaling"]["min_scaling"], instance_config)
+    ip_ready = hetzner_check_alive(instance_config)
     return ip_ready

--- a/cloudproxy/providers/manager.py
+++ b/cloudproxy/providers/manager.py
@@ -7,43 +7,76 @@ from cloudproxy.providers.digitalocean.main import do_start
 from cloudproxy.providers.hetzner.main import hetzner_start
 
 
-def do_manager():
-    ip_list = do_start()
-    settings.config["providers"]["digitalocean"]["ips"] = [ip for ip in ip_list]
+def do_manager(instance_name="default"):
+    """
+    DigitalOcean manager function for a specific instance.
+    """
+    instance_config = settings.config["providers"]["digitalocean"]["instances"][instance_name]
+    ip_list = do_start(instance_config)
+    settings.config["providers"]["digitalocean"]["instances"][instance_name]["ips"] = [ip for ip in ip_list]
     return ip_list
 
-def aws_manager():
-    ip_list = aws_start()
-    settings.config["providers"]["aws"]["ips"] = [ip for ip in ip_list]
+
+def aws_manager(instance_name="default"):
+    """
+    AWS manager function for a specific instance.
+    """
+    instance_config = settings.config["providers"]["aws"]["instances"][instance_name]
+    ip_list = aws_start(instance_config)
+    settings.config["providers"]["aws"]["instances"][instance_name]["ips"] = [ip for ip in ip_list]
     return ip_list
 
-def gcp_manager():
-    ip_list = gcp_start()
-    settings.config["providers"]["gcp"]["ips"] = [ip for ip in ip_list]
+
+def gcp_manager(instance_name="default"):
+    """
+    GCP manager function for a specific instance.
+    """
+    instance_config = settings.config["providers"]["gcp"]["instances"][instance_name]
+    ip_list = gcp_start(instance_config)
+    settings.config["providers"]["gcp"]["instances"][instance_name]["ips"] = [ip for ip in ip_list]
     return ip_list
 
-def hetzner_manager():
-    ip_list = hetzner_start()
-    settings.config["providers"]["hetzner"]["ips"] = [ip for ip in ip_list]
+
+def hetzner_manager(instance_name="default"):
+    """
+    Hetzner manager function for a specific instance.
+    """
+    instance_config = settings.config["providers"]["hetzner"]["instances"][instance_name]
+    ip_list = hetzner_start(instance_config)
+    settings.config["providers"]["hetzner"]["instances"][instance_name]["ips"] = [ip for ip in ip_list]
     return ip_list
 
 
 def init_schedule():
     sched = BackgroundScheduler()
     sched.start()
-    if settings.config["providers"]["digitalocean"]["enabled"]:
-        sched.add_job(do_manager, "interval", seconds=20)
-    else:
-        logger.info("DigitalOcean not enabled")
-    if settings.config["providers"]["aws"]["enabled"]:
-        sched.add_job(aws_manager, "interval", seconds=20)
-    else:
-        logger.info("AWS not enabled")
-    if settings.config["providers"]["gcp"]["enabled"]:
-        sched.add_job(gcp_manager, "interval", seconds=20)
-    else:
-        logger.info("GCP not enabled")
-    if settings.config["providers"]["hetzner"]["enabled"]:
-        sched.add_job(hetzner_manager, "interval", seconds=20)
-    else:
-        logger.info("Hetzner not enabled")
+    
+    # Define provider manager mapping
+    provider_managers = {
+        "digitalocean": do_manager,
+        "aws": aws_manager,
+        "gcp": gcp_manager,
+        "hetzner": hetzner_manager,
+    }
+    
+    # Schedule jobs for all provider instances
+    for provider_name, provider_config in settings.config["providers"].items():
+        # Skip providers not in our manager mapping
+        if provider_name not in provider_managers:
+            continue
+            
+        for instance_name, instance_config in provider_config["instances"].items():
+            if instance_config["enabled"]:
+                manager_func = provider_managers.get(provider_name)
+                if manager_func:
+                    # Create a function that preserves the original name
+                    def scheduled_func(func=manager_func, instance=instance_name):
+                        return func(instance)
+                    
+                    # Preserve the original function name for testing
+                    scheduled_func.__name__ = manager_func.__name__
+                    
+                    sched.add_job(scheduled_func, "interval", seconds=20)
+                    logger.info(f"{provider_name.capitalize()} {instance_name} enabled")
+            else:
+                logger.info(f"{provider_name.capitalize()} {instance_name} not enabled")

--- a/cloudproxy/providers/settings.py
+++ b/cloudproxy/providers/settings.py
@@ -8,24 +8,36 @@ config = {
     "age_limit": 0,
     "providers": {
         "digitalocean": {
+            "instances": {
+                "default": {
             "enabled": False,
             "ips": [],
             "scaling": {"min_scaling": 0, "max_scaling": 0},
             "size": "",
             "region": "",
+                    "display_name": "DigitalOcean",
             "secrets": {"access_token": ""},
+                }
+            }
         },
         "aws": {
+            "instances": {
+                "default": {
             "enabled": False,
             "ips": [],
             "scaling": {"min_scaling": 0, "max_scaling": 0},
             "size": "",
             "region": "",
             "ami": "",
+                    "display_name": "AWS",
             "secrets": {"access_key_id": "", "secret_access_key": ""},
             "spot": False,
+                }
+            }
         },
         "gcp": {
+            "instances": {
+                "default": {
             "enabled": False,
             "project": "",
             "ips": [],
@@ -34,16 +46,43 @@ config = {
             "zone": "",
             "image_project": "",
             "image_family": "",
+                    "display_name": "GCP",
             "secrets": {"service_account_key": ""},
+                }
+            }
         },
         "hetzner": {
+            "instances": {
+                "default": {
             "enabled": False,
             "ips": [],
             "scaling": {"min_scaling": 0, "max_scaling": 0},
             "size": "",
             "location": "",
             "datacenter": "",
+                    "display_name": "Hetzner",
             "secrets": {"access_token": ""},
+                }
+            }
+        },
+        "azure": {
+            "instances": {
+                "default": {
+                    "enabled": False,
+                    "ips": [],
+                    "scaling": {"min_scaling": 0, "max_scaling": 0},
+                    "size": "",
+                    "location": "",
+                    "display_name": "Azure",
+                    "secrets": {
+                        "subscription_id": "",
+                        "client_id": "",
+                        "client_secret": "",
+                        "tenant_id": "",
+                        "resource_group": ""
+                    },
+                }
+            }
         },
     },
 }
@@ -60,82 +99,189 @@ config["age_limit"] = int(os.environ.get('AGE_LIMIT', 0))
 config["no_auth"] = config["auth"]["username"] == "changeme" and config["auth"]["password"] == "changeme"
 config["only_host_ip"] = os.environ.get("ONLY_HOST_IP", False)
 
-# Set DigitalOcean config
-config["providers"]["digitalocean"]["enabled"] = os.environ.get(
+# Set DigitalOcean config - original format for backward compatibility
+config["providers"]["digitalocean"]["instances"]["default"]["enabled"] = os.environ.get(
     "DIGITALOCEAN_ENABLED", "False"
 ) == "True"
-config["providers"]["digitalocean"]["secrets"]["access_token"] = os.environ.get(
+config["providers"]["digitalocean"]["instances"]["default"]["secrets"]["access_token"] = os.environ.get(
     "DIGITALOCEAN_ACCESS_TOKEN"
 )
-config["providers"]["digitalocean"]["scaling"]["min_scaling"] = int(
+config["providers"]["digitalocean"]["instances"]["default"]["scaling"]["min_scaling"] = int(
     os.environ.get("DIGITALOCEAN_MIN_SCALING", 2)
 )
-config["providers"]["digitalocean"]["scaling"]["max_scaling"] = int(
+config["providers"]["digitalocean"]["instances"]["default"]["scaling"]["max_scaling"] = int(
     os.environ.get("DIGITALOCEAN_MAX_SCALING", 2)
 )
-config["providers"]["digitalocean"]["size"] = os.environ.get(
+config["providers"]["digitalocean"]["instances"]["default"]["size"] = os.environ.get(
     "DIGITALOCEAN_SIZE", "s-1vcpu-1gb"
 )
-config["providers"]["digitalocean"]["region"] = os.environ.get(
+config["providers"]["digitalocean"]["instances"]["default"]["region"] = os.environ.get(
     "DIGITALOCEAN_REGION", "lon1"
 )
+config["providers"]["digitalocean"]["instances"]["default"]["display_name"] = os.environ.get(
+    "DIGITALOCEAN_DISPLAY_NAME", "DigitalOcean"
+)
 
-# Set AWS Config
-config["providers"]["aws"]["enabled"] = os.environ.get("AWS_ENABLED", "False") == "True"
-config["providers"]["aws"]["secrets"]["access_key_id"] = os.environ.get(
+# Set AWS Config - original format for backward compatibility
+config["providers"]["aws"]["instances"]["default"]["enabled"] = os.environ.get("AWS_ENABLED", "False") == "True"
+config["providers"]["aws"]["instances"]["default"]["secrets"]["access_key_id"] = os.environ.get(
     "AWS_ACCESS_KEY_ID"
 )
-config["providers"]["aws"]["secrets"]["secret_access_key"] = os.environ.get(
+config["providers"]["aws"]["instances"]["default"]["secrets"]["secret_access_key"] = os.environ.get(
     "AWS_SECRET_ACCESS_KEY"
 )
-config["providers"]["aws"]["scaling"]["min_scaling"] = int(
+config["providers"]["aws"]["instances"]["default"]["scaling"]["min_scaling"] = int(
     os.environ.get("AWS_MIN_SCALING", 2)
 )
-config["providers"]["aws"]["scaling"]["max_scaling"] = int(
+config["providers"]["aws"]["instances"]["default"]["scaling"]["max_scaling"] = int(
     os.environ.get("AWS_MAX_SCALING", 2)
 )
-config["providers"]["aws"]["size"] = os.environ.get("AWS_SIZE", "t2.micro")
-config["providers"]["aws"]["region"] = os.environ.get("AWS_REGION", "eu-west-2")
-config["providers"]["aws"]["spot"] = os.environ.get("AWS_SPOT", "False") == "True"
-config["providers"]["aws"]["ami"] = os.environ.get("AWS_AMI", "ami-096cb92bb3580c759")
+config["providers"]["aws"]["instances"]["default"]["size"] = os.environ.get("AWS_SIZE", "t2.micro")
+config["providers"]["aws"]["instances"]["default"]["region"] = os.environ.get("AWS_REGION", "eu-west-2")
+config["providers"]["aws"]["instances"]["default"]["spot"] = os.environ.get("AWS_SPOT", "False") == "True"
+config["providers"]["aws"]["instances"]["default"]["ami"] = os.environ.get("AWS_AMI", "ami-096cb92bb3580c759")
+config["providers"]["aws"]["instances"]["default"]["display_name"] = os.environ.get("AWS_DISPLAY_NAME", "AWS")
 
-# Set GCP Config
-config["providers"]["gcp"]["enabled"] = os.environ.get("GCP_ENABLED", "False") == "True"
-config["providers"]["gcp"]["project"] = os.environ.get("GCP_PROJECT")
-config["providers"]["gcp"]["secrets"]["service_account_key"] = os.environ.get(
+# Set GCP Config - original format for backward compatibility
+config["providers"]["gcp"]["instances"]["default"]["enabled"] = os.environ.get("GCP_ENABLED", "False") == "True"
+config["providers"]["gcp"]["instances"]["default"]["project"] = os.environ.get("GCP_PROJECT")
+config["providers"]["gcp"]["instances"]["default"]["secrets"]["service_account_key"] = os.environ.get(
     "GCP_SERVICE_ACCOUNT_KEY"
 )
-
-config["providers"]["gcp"]["scaling"]["min_scaling"] = int(
+config["providers"]["gcp"]["instances"]["default"]["scaling"]["min_scaling"] = int(
     os.environ.get("GCP_MIN_SCALING", 2)
 )
-config["providers"]["gcp"]["scaling"]["max_scaling"] = int(
+config["providers"]["gcp"]["instances"]["default"]["scaling"]["max_scaling"] = int(
     os.environ.get("GCP_MAX_SCALING", 2)
 )
-config["providers"]["gcp"]["size"] = os.environ.get("GCP_SIZE", "f1-micro")
-config["providers"]["gcp"]["zone"] = os.environ.get("GCP_REGION", "us-central1-a")
-config["providers"]["gcp"]["image_project"] = os.environ.get("GCP_IMAGE_PROJECT", "ubuntu-os-cloud")
-config["providers"]["gcp"]["image_family"] = os.environ.get("GCP_IMAGE_FAMILY", "ubuntu-minimal-2004-lts")
+config["providers"]["gcp"]["instances"]["default"]["size"] = os.environ.get("GCP_SIZE", "f1-micro")
+config["providers"]["gcp"]["instances"]["default"]["zone"] = os.environ.get("GCP_REGION", "us-central1-a")
+config["providers"]["gcp"]["instances"]["default"]["image_project"] = os.environ.get("GCP_IMAGE_PROJECT", "ubuntu-os-cloud")
+config["providers"]["gcp"]["instances"]["default"]["image_family"] = os.environ.get("GCP_IMAGE_FAMILY", "ubuntu-minimal-2004-lts")
+config["providers"]["gcp"]["instances"]["default"]["display_name"] = os.environ.get("GCP_DISPLAY_NAME", "GCP")
 
-# Set Hetzner config
-config["providers"]["hetzner"]["enabled"] = os.environ.get(
+# Set Hetzner config - original format for backward compatibility
+config["providers"]["hetzner"]["instances"]["default"]["enabled"] = os.environ.get(
     "HETZNER_ENABLED", "False"
 ) == "True"
-config["providers"]["hetzner"]["secrets"]["access_token"] = os.environ.get(
+config["providers"]["hetzner"]["instances"]["default"]["secrets"]["access_token"] = os.environ.get(
     "HETZNER_ACCESS_TOKEN"
 )
-config["providers"]["hetzner"]["scaling"]["min_scaling"] = int(
+config["providers"]["hetzner"]["instances"]["default"]["scaling"]["min_scaling"] = int(
     os.environ.get("HETZNER_MIN_SCALING", 2)
 )
-config["providers"]["hetzner"]["scaling"]["max_scaling"] = int(
+config["providers"]["hetzner"]["instances"]["default"]["scaling"]["max_scaling"] = int(
     os.environ.get("HETZNER_MAX_SCALING", 2)
 )
-config["providers"]["hetzner"]["size"] = os.environ.get(
+config["providers"]["hetzner"]["instances"]["default"]["size"] = os.environ.get(
     "HETZNER_SIZE", "cx21"
 )
-config["providers"]["hetzner"]["location"] = os.environ.get(
+config["providers"]["hetzner"]["instances"]["default"]["location"] = os.environ.get(
     "HETZNER_LOCATION", "nbg1"
 )
-# config["providers"]["hetzner"]["datacenter"] = os.environ.get(
-#     "HETZNER_DATACENTER", "dc3"
-# )
+config["providers"]["hetzner"]["instances"]["default"]["display_name"] = os.environ.get(
+    "HETZNER_DISPLAY_NAME", "Hetzner"
+)
+
+# Set Azure config - original format for backward compatibility
+config["providers"]["azure"]["instances"]["default"]["enabled"] = os.environ.get(
+    "AZURE_ENABLED", "False"
+) == "True"
+config["providers"]["azure"]["instances"]["default"]["secrets"]["subscription_id"] = os.environ.get(
+    "AZURE_SUBSCRIPTION_ID"
+)
+config["providers"]["azure"]["instances"]["default"]["secrets"]["client_id"] = os.environ.get(
+    "AZURE_CLIENT_ID"
+)
+config["providers"]["azure"]["instances"]["default"]["secrets"]["client_secret"] = os.environ.get(
+    "AZURE_CLIENT_SECRET"
+)
+config["providers"]["azure"]["instances"]["default"]["secrets"]["tenant_id"] = os.environ.get(
+    "AZURE_TENANT_ID"
+)
+config["providers"]["azure"]["instances"]["default"]["secrets"]["resource_group"] = os.environ.get(
+    "AZURE_RESOURCE_GROUP", "cloudproxy-rg"
+)
+config["providers"]["azure"]["instances"]["default"]["scaling"]["min_scaling"] = int(
+    os.environ.get("AZURE_MIN_SCALING", 2)
+)
+config["providers"]["azure"]["instances"]["default"]["scaling"]["max_scaling"] = int(
+    os.environ.get("AZURE_MAX_SCALING", 2)
+)
+config["providers"]["azure"]["instances"]["default"]["size"] = os.environ.get(
+    "AZURE_SIZE", "Standard_B1s"
+)
+config["providers"]["azure"]["instances"]["default"]["location"] = os.environ.get(
+    "AZURE_LOCATION", "eastus"
+)
+config["providers"]["azure"]["instances"]["default"]["display_name"] = os.environ.get(
+    "AZURE_DISPLAY_NAME", "Azure"
+)
+
+# Check for additional provider instances using the new format pattern
+for provider_key in config["providers"].keys():
+    provider_upper = provider_key.upper()
+    
+    # Find all environment variables matching the pattern {PROVIDER}_INSTANCE_{NAME}_ENABLED
+    instance_vars = {key: value for key, value in os.environ.items() 
+                    if key.startswith(f"{provider_upper}_INSTANCE_") and key.endswith("_ENABLED")}
+    
+    for instance_var, enabled_value in instance_vars.items():
+        # Extract instance name from the environment variable key
+        # Format: {PROVIDER}_INSTANCE_{NAME}_ENABLED
+        instance_name = instance_var[len(f"{provider_upper}_INSTANCE_"):-8].lower()
+        
+        if enabled_value == "True":
+            # Create a new instance configuration
+            if instance_name not in config["providers"][provider_key]["instances"]:
+                # Clone the default instance configuration as a starting point
+                config["providers"][provider_key]["instances"][instance_name] = {
+                    "enabled": True,
+                    "ips": [],
+                    "scaling": {"min_scaling": 0, "max_scaling": 0},
+                    "size": "",
+                    "display_name": f"{provider_key.capitalize()} {instance_name}",
+                    "secrets": {},
+                }
+                
+                # Copy relevant fields from default instance
+                default_instance = config["providers"][provider_key]["instances"]["default"]
+                for field in ["region", "zone", "location", "ami", "spot", "datacenter", 
+                             "image_project", "image_family", "project"]:
+                    if field in default_instance:
+                        config["providers"][provider_key]["instances"][instance_name][field] = default_instance[field]
+                
+                # Copy secrets structure (but not values)
+                for secret_key in default_instance["secrets"].keys():
+                    config["providers"][provider_key]["instances"][instance_name]["secrets"][secret_key] = None
+            
+            # Set instance-specific values from environment variables
+            instance_prefix = f"{provider_upper}_INSTANCE_{instance_name.upper()}_"
+            
+            # Process all environment variables for this instance
+            for env_key, env_value in os.environ.items():
+                if env_key.startswith(instance_prefix):
+                    # Extract the setting name
+                    setting_name = env_key[len(instance_prefix):].lower()
+                    
+                    if setting_name == "min_scaling":
+                        config["providers"][provider_key]["instances"][instance_name]["scaling"]["min_scaling"] = int(env_value)
+                    elif setting_name == "max_scaling":
+                        config["providers"][provider_key]["instances"][instance_name]["scaling"]["max_scaling"] = int(env_value)
+                    elif setting_name == "display_name":
+                        config["providers"][provider_key]["instances"][instance_name]["display_name"] = env_value
+                    elif setting_name in ["size", "region", "zone", "location", "ami", "project", 
+                                          "image_project", "image_family", "datacenter"]:
+                        config["providers"][provider_key]["instances"][instance_name][setting_name] = env_value
+                    elif setting_name == "spot":
+                        config["providers"][provider_key]["instances"][instance_name]["spot"] = env_value == "True"
+                    elif setting_name in default_instance["secrets"]:
+                        # Handle secret values
+                        config["providers"][provider_key]["instances"][instance_name]["secrets"][setting_name] = env_value
+
+# For backward compatibility - maintain top-level properties for the default instance
+for provider_key in config["providers"].keys():
+    default_instance = config["providers"][provider_key]["instances"]["default"]
+    for key, value in default_instance.items():
+        if key != "secrets":  # Don't include secrets in top-level
+            config["providers"][provider_key][key] = value

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,7 +31,10 @@ All API responses follow a standardized format that includes:
   "ip": "192.168.1.1",
   "port": 8899,
   "auth_enabled": true,
-  "url": "http://username:password@192.168.1.1:8899"
+  "url": "http://username:password@192.168.1.1:8899",
+  "provider": "digitalocean",
+  "instance": "default",
+  "display_name": "My DigitalOcean Instance"
 }
 ```
 
@@ -45,7 +48,44 @@ All API responses follow a standardized format that includes:
     "max_scaling": 5
   },
   "size": "s-1vcpu-1gb",
-  "region": "lon1"
+  "region": "lon1",
+  "instances": {
+    "default": {
+      "enabled": true,
+      "ips": ["192.168.1.1", "192.168.1.2"],
+      "scaling": {
+        "min_scaling": 2,
+        "max_scaling": 5
+      },
+      "size": "s-1vcpu-1gb",
+      "region": "lon1"
+    },
+    "second-account": {
+      "enabled": true,
+      "ips": ["192.168.1.3", "192.168.1.4"],
+      "scaling": {
+        "min_scaling": 1,
+        "max_scaling": 3
+      },
+      "size": "s-1vcpu-1gb",
+      "region": "nyc1"
+    }
+  }
+}
+```
+
+### Provider Instance Object
+```json
+{
+  "enabled": true,
+  "ips": ["192.168.1.1", "192.168.1.2"],
+  "scaling": {
+    "min_scaling": 2,
+    "max_scaling": 5
+  },
+  "size": "s-1vcpu-1gb",
+  "region": "lon1",
+  "display_name": "My DigitalOcean Instance"
 }
 ```
 
@@ -66,7 +106,10 @@ All API responses follow a standardized format that includes:
       "ip": "192.168.1.1",
       "port": 8899,
       "auth_enabled": true,
-      "url": "http://username:password@192.168.1.1:8899"
+      "url": "http://username:password@192.168.1.1:8899",
+      "provider": "digitalocean",
+      "instance": "default",
+      "display_name": "My DigitalOcean Instance"
     }
   ]
 }
@@ -84,7 +127,10 @@ All API responses follow a standardized format that includes:
     "ip": "192.168.1.1",
     "port": 8899,
     "auth_enabled": true,
-    "url": "http://username:password@192.168.1.1:8899"
+    "url": "http://username:password@192.168.1.1:8899",
+    "provider": "digitalocean",
+    "instance": "default",
+    "display_name": "My DigitalOcean Instance"
   }
 }
 ```
@@ -125,7 +171,7 @@ All API responses follow a standardized format that includes:
 
 #### List All Providers
 - `GET /providers`
-- Returns configuration and status for all providers
+- Returns configuration and status for all providers, including all instances
 - Response format:
 ```json
 {
@@ -139,7 +185,29 @@ All API responses follow a standardized format that includes:
         "max_scaling": 5
       },
       "size": "s-1vcpu-1gb",
-      "region": "lon1"
+      "region": "lon1",
+      "instances": {
+        "default": {
+          "enabled": true,
+          "ips": ["192.168.1.1", "192.168.1.2"],
+          "scaling": {
+            "min_scaling": 2,
+            "max_scaling": 5
+          },
+          "size": "s-1vcpu-1gb",
+          "region": "lon1"
+        },
+        "second-account": {
+          "enabled": true,
+          "ips": ["192.168.1.3", "192.168.1.4"],
+          "scaling": {
+            "min_scaling": 1,
+            "max_scaling": 3
+          },
+          "size": "s-1vcpu-1gb",
+          "region": "nyc1"
+        }
+      }
     },
     "aws": { ... }
   }
@@ -148,7 +216,7 @@ All API responses follow a standardized format that includes:
 
 #### Get Provider Details
 - `GET /providers/{provider}`
-- Returns detailed information for a specific provider
+- Returns detailed information for a specific provider, including all instances
 - Response format:
 ```json
 {
@@ -163,13 +231,35 @@ All API responses follow a standardized format that includes:
     },
     "size": "s-1vcpu-1gb",
     "region": "lon1"
+  },
+  "instances": {
+    "default": {
+      "enabled": true,
+      "ips": ["192.168.1.1", "192.168.1.2"],
+      "scaling": {
+        "min_scaling": 2,
+        "max_scaling": 5
+      },
+      "size": "s-1vcpu-1gb",
+      "region": "lon1"
+    },
+    "second-account": {
+      "enabled": true,
+      "ips": ["192.168.1.3", "192.168.1.4"],
+      "scaling": {
+        "min_scaling": 1,
+        "max_scaling": 3
+      },
+      "size": "s-1vcpu-1gb",
+      "region": "nyc1"
+    }
   }
 }
 ```
 
 #### Update Provider Scaling
 - `PATCH /providers/{provider}`
-- Updates the scaling configuration for a provider
+- Updates the scaling configuration for the default instance of a provider
 - Request body:
 ```json
 {
@@ -178,6 +268,43 @@ All API responses follow a standardized format that includes:
 }
 ```
 - Response format matches Get Provider Details
+- Validation ensures max_scaling >= min_scaling
+
+#### Get Provider Instance Details
+- `GET /providers/{provider}/{instance}`
+- Returns detailed information for a specific instance of a provider
+- Response format:
+```json
+{
+  "metadata": { ... },
+  "message": "Provider 'digitalocean' instance 'default' configuration retrieved successfully",
+  "provider": "digitalocean",
+  "instance": "default",
+  "config": {
+    "enabled": true,
+    "ips": ["192.168.1.1", "192.168.1.2"],
+    "scaling": {
+      "min_scaling": 2,
+      "max_scaling": 5
+    },
+    "size": "s-1vcpu-1gb",
+    "region": "lon1",
+    "display_name": "My DigitalOcean Instance"
+  }
+}
+```
+
+#### Update Provider Instance Scaling
+- `PATCH /providers/{provider}/{instance}`
+- Updates the scaling configuration for a specific instance of a provider
+- Request body:
+```json
+{
+  "min_scaling": 2,
+  "max_scaling": 5
+}
+```
+- Response format matches Get Provider Instance Details
 - Validation ensures max_scaling >= min_scaling
 
 ## Error Responses

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -1,37 +1,91 @@
 # AWS Configuration
 
-To use AWS as a provider, you’ll first need to create an IAM User.
+To use AWS as a provider, you'll need to set up credentials for authentication.
 
-## Steps
+## AWS IAM Setup
 
-1. Login to your AWS console.
-2. Go to Identity and Access Management (IAM).
-3. On the left-hand panel, click 'Users'.
-4. Click 'Add user'.
-5. Choose a username e.g. CloudProxy and select 'Programmatic access', then click Next.
-6. Click 'Attach existing policies directly' and then select 'AmazonEC2FullAccess', then click Next.
-7. Tag is optional, you may want to create the key as 'CloudProxy', then click Next.
-8. Now Review and then click 'Create user'.
+1. Login to the AWS Management Console
+2. Go to the IAM service
+3. Create a new IAM policy with the following permissions:
+   - EC2 (for managing instances): DescribeInstances, RunInstances, TerminateInstances, CreateTags, DescribeImages, DescribeInstanceStatus, DescribeInstanceTypes, DescribeAvailabilityZones, DescribeSecurityGroups, AuthorizeSecurityGroupIngress
+   - Systems Manager (for configuring instances): SendCommand
+4. Create a new IAM user or role and attach the policy
+5. Generate access key ID and secret access key
 
-Now you have your access key and secret access key, you can now use AWS as a proxy provider, below details of the environment variables.
+## Environment Variables
 
-## Configuration options
-### Environment variables: 
-#### Required:
-`` AWS_ENABLED`` - to enable AWS as a provider, set as True. Default value: False
+### Required:
+``AWS_ENABLED`` - to enable AWS as a provider, set as True. Default value: False
 
-`` AWS_ACCESS_KEY_ID`` - the access key to allow CloudProxy access to your account. 
+``AWS_ACCESS_KEY_ID`` - the access key ID for CloudProxy to authenticate with AWS.
 
-`` AWS_SECRET_ACCESS_KEY`` - the secret access key to allow CloudProxy access to your account.
-#### Optional:
-``AWS_MIN_SCALING`` - this is the minimal proxies you required to be provisioned. Default value: 2
+``AWS_SECRET_ACCESS_KEY`` - the secret access key for CloudProxy to authenticate with AWS.
 
-``AWS_MAX_SCALING`` - this is currently unused, however will be when autoscaling is implemented. We recommend you set this as the same as the minimum scaling to avoid future issues for now. Default value: 2
+### Optional:
+``AWS_REGION`` - the AWS region where instances will be deployed, e.g., eu-west-2. Default: us-east-1
 
-``AWS_SIZE``  - this sets the instance size, we recommend the smallest instance as the volume even a small instance can handle is high. Default value: t2.micro
+``AWS_AMI`` - the Amazon Machine Image (AMI) ID to use for instances. This should be Ubuntu 22.04. Default: region-specific default AMI
 
-``AWS_SPOT`` - use this to launch instances as spot instances. The available options are 'persistent' (if you want to be able to restart them) or 'one-time' (if you plan to terminate them). Not all sizes are able to be launched as spot instances. Default value: False
+``AWS_MIN_SCALING`` - minimum number of proxies to provision. Default: 2
 
-``AWS_REGION`` - this sets the region where the instance is deployed. Some websites may redirect to the language of the country your IP is from. Default value: eu-west-2
+``AWS_MAX_SCALING`` - maximum number of proxies to provision. Default: 2
 
-``AWS_AMI`` - this sets the AMI the instance is deployed with. The default AMI is for Ubuntu 20.04, however each region may use a different AMI ID. If not using eu-west-2, you may need to set a different AMI ID. See the AWS AMI Marketplace for Ubuntu 20.04 AMI IDs. Default value: ami-096cb92bb3580c759
+``AWS_SIZE`` - the instance type to use. t2.micro is included in the free tier. Default: t2.micro
+
+``AWS_SPOT`` - whether to use spot instances (can be cheaper but may be terminated by AWS). Set to True or False. Default: False
+
+## Multi-Account Support
+
+CloudProxy supports running multiple AWS accounts simultaneously. Each account is configured as a separate "instance" with its own settings.
+
+### Default Instance Configuration
+
+The configuration variables mentioned above configure the "default" instance. For example:
+
+```
+AWS_ENABLED=True
+AWS_ACCESS_KEY_ID=your_default_access_key
+AWS_SECRET_ACCESS_KEY=your_default_secret_key
+AWS_REGION=us-east-1
+AWS_MIN_SCALING=2
+```
+
+### Additional Instances Configuration
+
+To configure additional AWS accounts, use the following format:
+```
+AWS_INSTANCENAME_VARIABLE=VALUE
+```
+
+For example, to add a second AWS account in a different region:
+
+```
+AWS_EU_ENABLED=True
+AWS_EU_ACCESS_KEY_ID=your_second_access_key
+AWS_EU_SECRET_ACCESS_KEY=your_second_secret_key
+AWS_EU_REGION=eu-west-1
+AWS_EU_MIN_SCALING=1
+AWS_EU_SIZE=t2.micro
+AWS_EU_SPOT=True
+AWS_EU_DISPLAY_NAME=EU Account
+```
+
+### Available instance-specific configurations
+
+For each instance, you can configure:
+
+#### Required for each instance:
+- `AWS_INSTANCENAME_ENABLED` - to enable this specific instance
+- `AWS_INSTANCENAME_ACCESS_KEY_ID` - AWS access key ID for this instance
+- `AWS_INSTANCENAME_SECRET_ACCESS_KEY` - AWS secret access key for this instance
+
+#### Optional for each instance:
+- `AWS_INSTANCENAME_REGION` - AWS region for this instance
+- `AWS_INSTANCENAME_AMI` - AMI ID for this instance (region-specific)
+- `AWS_INSTANCENAME_MIN_SCALING` - minimum number of proxies for this instance
+- `AWS_INSTANCENAME_MAX_SCALING` - maximum number of proxies for this instance
+- `AWS_INSTANCENAME_SIZE` - instance type for this instance
+- `AWS_INSTANCENAME_SPOT` - whether to use spot instances for this instance
+- `AWS_INSTANCENAME_DISPLAY_NAME` - a friendly name for the instance that will appear in the UI
+
+Each instance operates independently, maintaining its own pool of proxies according to its configuration.

--- a/docs/digitalocean.md
+++ b/docs/digitalocean.md
@@ -1,6 +1,6 @@
 # DigitalOcean Configuration
 
-To use DigitalOcean as a provider, you’ll first generate a personal access token.
+To use DigitalOcean as a provider, you'll first generate a personal access token.
 
 ## Steps
 
@@ -16,9 +16,11 @@ Now you have your token, you can now use DigitalOcean as a proxy provider, on th
 ## Configuration options
 ### Environment variables: 
 #### Required:
-`` DIGITALOCEAN_ENABLED`` - to enable DigitalOcean as a provider, set as True. Default value: False
+``DIGITALOCEAN_ENABLED`` - to enable DigitalOcean as a provider, set as True. Default value: False
 
-`` DIGITALOCEAN_ACCESS_TOKEN`` - the token to allow CloudProxy access to your account. 
+``DIGITALOCEAN_ACCESS_TOKEN`` - the token to allow CloudProxy access to your account. 
+
+``DIGITALOCEAN_REGION`` - this sets the region where the droplet is deployed. Some websites may redirect to the language of the country your IP is from. Default value: lon1
 
 #### Optional:
 ``DIGITALOCEAN_MIN_SCALING`` - this is the minimal proxies you required to be provisioned. 
@@ -28,4 +30,52 @@ Default value: 2
 
 ``DIGITALOCEAN_SIZE``  - this sets the droplet size, we recommend the smallest droplet as the volume even a small droplet can handle is high. Default value: s-1vcpu-1gb
 
-``DIGITALOCEAN_REGION`` - this sets the region where the droplet is deployed. Some websites may redirect to the language of the country your IP is from. Default value: lon1
+## Multi-Account Support
+
+CloudProxy supports running multiple DigitalOcean accounts simultaneously. Each account is configured as a separate "instance" with its own settings.
+
+### Default Instance Configuration
+
+The configuration variables mentioned above configure the "default" instance. For example:
+
+```
+DIGITALOCEAN_ENABLED=True
+DIGITALOCEAN_ACCESS_TOKEN=your_default_token
+DIGITALOCEAN_REGION=lon1
+DIGITALOCEAN_MIN_SCALING=2
+```
+
+### Additional Instances Configuration
+
+To configure additional DigitalOcean accounts, use the following format:
+```
+DIGITALOCEAN_INSTANCENAME_VARIABLE=VALUE
+```
+
+For example, to add a second DigitalOcean account with different region settings:
+
+```
+DIGITALOCEAN_USEAST_ENABLED=True
+DIGITALOCEAN_USEAST_ACCESS_TOKEN=your_second_token
+DIGITALOCEAN_USEAST_REGION=nyc1
+DIGITALOCEAN_USEAST_MIN_SCALING=3
+DIGITALOCEAN_USEAST_SIZE=s-1vcpu-1gb
+DIGITALOCEAN_USEAST_DISPLAY_NAME=US East Account
+```
+
+### Available instance-specific configurations
+
+For each instance, you can configure:
+
+#### Required for each instance:
+- `DIGITALOCEAN_INSTANCENAME_ENABLED` - to enable this specific instance
+- `DIGITALOCEAN_INSTANCENAME_ACCESS_TOKEN` - the token for this instance
+- `DIGITALOCEAN_INSTANCENAME_REGION` - region for this instance
+
+#### Optional for each instance:
+- `DIGITALOCEAN_INSTANCENAME_MIN_SCALING` - minimum number of proxies for this instance
+- `DIGITALOCEAN_INSTANCENAME_MAX_SCALING` - maximum number of proxies for this instance
+- `DIGITALOCEAN_INSTANCENAME_SIZE` - droplet size for this instance
+- `DIGITALOCEAN_INSTANCENAME_DISPLAY_NAME` - a friendly name for the instance that will appear in the UI
+
+Each instance operates independently, maintaining its own pool of proxies according to its configuration.

--- a/docs/hetzner.md
+++ b/docs/hetzner.md
@@ -1,30 +1,85 @@
 # Hetzner Configuration
 
-To use Hetzner as a provider, you’ll first need to generate an API token.
+To use Hetzner as a provider, you'll need to generate an API token.
 
 ## Steps
 
-1. Login to your Hetzner Cloud account.
-2. Select a project, then on the left sidebar, select 'Security'.
-3. In the Security section, select 'API Tokens' on the top menu bar, click the Generate API Token button. This opens an API token window.
-4. Enter a token name, this can be anything, I recommend 'CloudProxy' so you know what it is being used for.
-5. Select 'Read & Write', write permission is needed so CloudProxy can provision instances.
-6. When you click 'Generate API Token', your token is generated and presented to you. Be sure to record your API token. For security purposes, it will not be shown again.
+1. Login to your [Hetzner Cloud Console](https://console.hetzner.cloud/).
+2. Select your project (or create a new one).
+3. Go to Security > API Tokens.
+4. Click "Generate API Token".
+5. Enter a token name (e.g., "CloudProxy").
+6. Select "Read & Write" for the permission.
+7. Click "Generate API Token".
+8. Copy the token immediately (it will only be displayed once).
 
-Now you have your token, you can now use Hetzner as a proxy provider, on this page you can see how to set it is an environment variable. 
+Now you have your token, you can use Hetzner as a proxy provider by configuring the environment variables as shown below.
 
 ## Configuration options
-### Environment variables: 
+### Environment variables:
 #### Required:
-`` HETZNER_ENABLED`` - to enable Hetzner as a provider, set as True. Default value: False
+``HETZNER_ENABLED`` - to enable Hetzner as a provider, set as True. Default value: False
 
-`` HETZNER_ACCESS_TOKEN`` - the token to allow CloudProxy access to your account. 
+``HETZNER_API_TOKEN`` - the API token to allow CloudProxy access to your account.
 
 #### Optional:
-``HETZNER_MIN_SCALING`` - this is the minimal proxies you required to be provisioned. Default value: 2
+``HETZNER_MIN_SCALING`` - the minimum number of proxies to provision. Default value: 2
 
-``HETZNER_MAX_SCALING`` - this is currently unused, however will be when autoscaling is implemented. We recommend you set this as the same as the minimum scaling to avoid future issues for now. Default value: 2
+``HETZNER_MAX_SCALING`` - currently unused, but will be when autoscaling is implemented. We recommend you set this to the same value as the minimum scaling to avoid future issues. Default value: 2
 
-``HETZNER_SIZE``  - this sets the instance size, we recommend the smallest instance as the volume even a small instance can handle is high. Default value: cx11
+``HETZNER_SIZE`` - the server type to use. Default value: cx11 (the smallest available server type)
 
-``HETZNER_LOCATION`` - this sets the location where the instance is deployed. Some websites may redirect to the language of the country your IP is from. Default value: nbg1
+``HETZNER_LOCATION`` - the location where the server will be deployed. Default value: nbg1 (Nuremberg, Germany)
+
+``HETZNER_DATACENTER`` - alternatively, you can specify a specific datacenter rather than just a location. Note that a datacenter value will override the location setting.
+
+## Multi-Account Support
+
+CloudProxy supports running multiple Hetzner accounts simultaneously. Each account is configured as a separate "instance" with its own settings.
+
+### Default Instance Configuration
+
+The configuration variables mentioned above configure the "default" instance. For example:
+
+```
+HETZNER_ENABLED=True
+HETZNER_API_TOKEN=your_default_token
+HETZNER_LOCATION=nbg1
+HETZNER_MIN_SCALING=2
+```
+
+### Additional Instances Configuration
+
+To configure additional Hetzner accounts, use the following format:
+```
+HETZNER_INSTANCENAME_VARIABLE=VALUE
+```
+
+For example, to add a second Hetzner account in a different location:
+
+```
+HETZNER_FINLAND_ENABLED=True
+HETZNER_FINLAND_API_TOKEN=your_second_token
+HETZNER_FINLAND_LOCATION=hel1
+HETZNER_FINLAND_MIN_SCALING=3
+HETZNER_FINLAND_SIZE=cx11
+HETZNER_FINLAND_DISPLAY_NAME=Finland Hetzner Account
+```
+
+### Available instance-specific configurations
+
+For each instance, you can configure:
+
+#### Required for each instance:
+- `HETZNER_INSTANCENAME_ENABLED` - to enable this specific instance
+- `HETZNER_INSTANCENAME_API_TOKEN` - the API token for this instance
+
+#### Optional for each instance:
+- `HETZNER_INSTANCENAME_MIN_SCALING` - minimum number of proxies for this instance
+- `HETZNER_INSTANCENAME_MAX_SCALING` - maximum number of proxies for this instance
+- `HETZNER_INSTANCENAME_SIZE` - server type for this instance
+- `HETZNER_INSTANCENAME_LOCATION` - location for this instance
+- `HETZNER_INSTANCENAME_DATACENTER` - datacenter for this instance (overrides location)
+- `HETZNER_INSTANCENAME_DISPLAY_NAME` - a friendly name for the instance that will appear in the UI
+
+Each instance operates independently, maintaining its own pool of proxies according to its configuration.

--- a/tests/test_api_providers.py
+++ b/tests/test_api_providers.py
@@ -1,0 +1,380 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+from cloudproxy.main import app
+from cloudproxy.providers import settings
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def mock_providers_config(monkeypatch):
+    """Fixture for mock provider configuration."""
+    mock_config = {
+        "providers": {
+            "digitalocean": {
+                "enabled": True,
+                "ips": ["192.168.1.1", "192.168.1.2", "192.168.2.1", "192.168.2.2"],  # Combined IPs from all instances
+                "instances": {
+                    "default": {
+                        "enabled": True,
+                        "secrets": {"access_token": "default-do-token"},
+                        "size": "s-1vcpu-1gb",
+                        "region": "lon1",
+                        "min_scaling": 2,
+                        "max_scaling": 5,
+                        "display_name": "London DO",
+                        "ips": ["192.168.1.1", "192.168.1.2"],
+                        "scaling": {"min_scaling": 2, "max_scaling": 5}
+                    },
+                    "nyc": {
+                        "enabled": True,
+                        "secrets": {"access_token": "nyc-do-token"},
+                        "size": "s-1vcpu-1gb",
+                        "region": "nyc1",
+                        "min_scaling": 1,
+                        "max_scaling": 3,
+                        "display_name": "New York DO",
+                        "ips": ["192.168.2.1", "192.168.2.2"],
+                        "scaling": {"min_scaling": 1, "max_scaling": 3}
+                    }
+                }
+            },
+            "aws": {
+                "enabled": True,
+                "ips": ["10.0.1.1", "10.0.1.2", "10.0.2.1", "10.0.2.2"],  # Combined IPs from all instances
+                "instances": {
+                    "default": {
+                        "enabled": True,
+                        "secrets": {
+                            "access_key_id": "default-aws-key",
+                            "secret_access_key": "default-aws-secret"
+                        },
+                        "size": "t2.micro",
+                        "region": "us-east-1",
+                        "min_scaling": 2,
+                        "max_scaling": 4,
+                        "spot": False,
+                        "display_name": "US East AWS",
+                        "ips": ["10.0.1.1", "10.0.1.2"],
+                        "scaling": {"min_scaling": 2, "max_scaling": 4}
+                    },
+                    "eu": {
+                        "enabled": True,
+                        "secrets": {
+                            "access_key_id": "eu-aws-key",
+                            "secret_access_key": "eu-aws-secret"
+                        },
+                        "size": "t2.micro",
+                        "region": "eu-west-1",
+                        "min_scaling": 1,
+                        "max_scaling": 2,
+                        "spot": True,
+                        "display_name": "EU West AWS",
+                        "ips": ["10.0.2.1", "10.0.2.2"],
+                        "scaling": {"min_scaling": 1, "max_scaling": 2}
+                    }
+                }
+            },
+            "hetzner": {
+                "enabled": True,
+                "ips": ["172.16.1.1", "172.16.1.2"],  # Combined IPs from all instances
+                "instances": {
+                    "default": {
+                        "enabled": True,
+                        "secrets": {"access_token": "default-hetzner-token"},
+                        "size": "cx11",
+                        "location": "nbg1",
+                        "min_scaling": 2,
+                        "max_scaling": 3,
+                        "display_name": "Germany Hetzner",
+                        "ips": ["172.16.1.1", "172.16.1.2"],
+                        "scaling": {"min_scaling": 2, "max_scaling": 3}
+                    }
+                }
+            },
+            "gcp": {
+                "enabled": False,
+                "zone": "us-east1-b",
+                "image_project": "debian-cloud",
+                "image_family": "debian-11",
+                "ips": [],  # No IPs since it's disabled
+                "scaling": {"min_scaling": 0, "max_scaling": 0},
+                "size": "e2-small",
+                "instances": {
+                    "default": {
+                        "enabled": False,
+                        "secrets": {"json_key": "mock-gcp-key"},
+                        "zone": "us-east1-b",
+                        "image_project": "debian-cloud",
+                        "image_family": "debian-11",
+                        "size": "e2-small",
+                        "min_scaling": 0,
+                        "max_scaling": 0,
+                        "display_name": "US East GCP",
+                        "ips": [],
+                        "scaling": {"min_scaling": 0, "max_scaling": 0}
+                    }
+                }
+            }
+        }
+    }
+    
+    monkeypatch.setattr(settings, "config", mock_config)
+    return mock_config["providers"]
+
+
+@pytest.fixture
+def mock_provider_ips():
+    """Fixture for mock provider IPs."""
+    # Original provider IPs
+    original_ips = {
+        provider: {
+            instance: settings.config["providers"][provider]["instances"][instance].get("ips", []).copy()
+            for instance in settings.config["providers"][provider]["instances"]
+        } 
+        for provider in settings.config["providers"]
+        if provider in settings.config["providers"]
+    }
+    
+    # Set mock IPs for each provider instance
+    mock_ips = {
+        "digitalocean": {
+            "default": ["192.168.1.1", "192.168.1.2"],
+            "nyc": ["192.168.2.1", "192.168.2.2"]
+        },
+        "aws": {
+            "default": ["10.0.1.1", "10.0.1.2"],
+            "eu": ["10.0.2.1", "10.0.2.2"]
+        },
+        "hetzner": {
+            "default": ["172.16.1.1", "172.16.1.2"]
+        }
+    }
+    
+    # Update config with mock IPs
+    for provider, instances in mock_ips.items():
+        for instance, ips in instances.items():
+            settings.config["providers"][provider]["instances"][instance]["ips"] = ips
+    
+    yield mock_ips
+    
+    # Restore original IPs
+    for provider, instances in original_ips.items():
+        for instance, ips in instances.items():
+            if provider in settings.config["providers"] and instance in settings.config["providers"][provider]["instances"]:
+                settings.config["providers"][provider]["instances"][instance]["ips"] = ips
+
+
+def test_get_providers_list(mock_providers_config, mock_provider_ips):
+    """Test retrieving the list of all providers with their instances."""
+    response = client.get("/providers")
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert "metadata" in data
+    assert "providers" in data
+    
+    providers = data["providers"]
+    
+    # Check DigitalOcean provider
+    assert "digitalocean" in providers
+    digitalocean = providers["digitalocean"]
+    assert digitalocean["enabled"] is True
+    assert len(digitalocean["ips"]) == 4  # Combined IPs from all instances
+    assert "instances" in digitalocean
+    
+    # Check DigitalOcean instances
+    do_instances = digitalocean["instances"]
+    assert "default" in do_instances
+    assert "nyc" in do_instances
+    assert do_instances["default"]["display_name"] == "London DO"
+    assert do_instances["nyc"]["display_name"] == "New York DO"
+    
+    # Check AWS provider
+    assert "aws" in providers
+    aws = providers["aws"]
+    assert aws["enabled"] is True
+    assert len(aws["ips"]) == 4  # Combined IPs from all instances
+    
+    # Check AWS instances
+    aws_instances = aws["instances"]
+    assert "default" in aws_instances
+    assert "eu" in aws_instances
+    assert aws_instances["default"]["display_name"] == "US East AWS"
+    assert aws_instances["eu"]["display_name"] == "EU West AWS"
+    assert aws_instances["eu"]["spot"] is True
+
+
+def test_get_provider_details(mock_providers_config, mock_provider_ips):
+    """Test retrieving details for a specific provider with all its instances."""
+    response = client.get("/providers/digitalocean")
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert "metadata" in data
+    assert "message" in data
+    assert "provider" in data
+    assert "instances" in data
+    
+    # Check provider details
+    provider = data["provider"]
+    assert provider["enabled"] is True
+    assert len(provider["ips"]) == 4  # Combined IPs from all instances
+    
+    # Check instances details
+    instances = data["instances"]
+    assert "default" in instances
+    assert "nyc" in instances
+    
+    default_instance = instances["default"]
+    assert default_instance["enabled"] is True
+    assert default_instance["region"] == "lon1"
+    assert default_instance["size"] == "s-1vcpu-1gb"
+    assert default_instance["min_scaling"] == 2
+    assert default_instance["max_scaling"] == 5
+    assert default_instance["display_name"] == "London DO"
+    assert len(default_instance["ips"]) == 2
+    
+    nyc_instance = instances["nyc"]
+    assert nyc_instance["enabled"] is True
+    assert nyc_instance["region"] == "nyc1"
+    assert nyc_instance["min_scaling"] == 1
+    assert nyc_instance["max_scaling"] == 3
+    assert nyc_instance["display_name"] == "New York DO"
+    assert len(nyc_instance["ips"]) == 2
+
+
+def test_get_provider_instance_details(mock_providers_config, mock_provider_ips):
+    """Test retrieving details for a specific instance of a provider."""
+    response = client.get("/providers/aws/eu")
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert "metadata" in data
+    assert "message" in data
+    assert "provider" in data
+    assert "instance" in data
+    assert "config" in data
+    
+    # Check response structure
+    assert data["provider"] == "aws"
+    assert data["instance"] == "eu"
+    
+    # Check instance config
+    config = data["config"]
+    assert config["enabled"] is True
+    assert config["region"] == "eu-west-1"
+    assert config["size"] == "t2.micro"
+    assert config["spot"] is True
+    assert "scaling" in config
+    assert config["scaling"]["min_scaling"] == 1
+    assert config["scaling"]["max_scaling"] == 2
+    assert config["display_name"] == "EU West AWS"
+    assert len(config["ips"]) == 2
+    assert config["ips"] == mock_provider_ips["aws"]["eu"]
+
+
+def test_update_provider_instance_scaling(mock_providers_config):
+    """Test updating scaling configuration for a provider instance."""
+    # Data to send
+    update_data = {
+        "min_scaling": 3,
+        "max_scaling": 5
+    }
+    
+    response = client.patch("/providers/aws/eu", json=update_data)
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert "message" in data
+    assert "updated successfully" in data["message"]
+    assert "aws" in data["message"]
+    assert "eu" in data["message"]
+    
+    # Verify config was updated
+    config = data["config"]
+    assert config["scaling"]["min_scaling"] == 3
+    assert config["scaling"]["max_scaling"] == 5
+    
+    # Verify actual settings were updated
+    assert settings.config["providers"]["aws"]["instances"]["eu"]["scaling"]["min_scaling"] == 3
+    assert settings.config["providers"]["aws"]["instances"]["eu"]["scaling"]["max_scaling"] == 5
+
+
+def test_update_provider_instance_scaling_validation_error(mock_providers_config):
+    """Test validation error when max_scaling < min_scaling."""
+    # Invalid data to send
+    update_data = {
+        "min_scaling": 5,
+        "max_scaling": 3  # Less than min_scaling
+    }
+    
+    response = client.patch("/providers/aws/eu", json=update_data)
+    assert response.status_code == 422  # Unprocessable Entity
+    
+    data = response.json()
+    assert "detail" in data
+    
+    # Original values should remain unchanged
+    assert settings.config["providers"]["aws"]["instances"]["eu"]["min_scaling"] == 1
+    assert settings.config["providers"]["aws"]["instances"]["eu"]["max_scaling"] == 2
+
+
+def test_get_nonexistent_provider():
+    """Test retrieving a provider that doesn't exist."""
+    response = client.get("/providers/nonexistent")
+    assert response.status_code == 404
+    
+    data = response.json()
+    assert "detail" in data
+    assert "nonexistent" in data["detail"]
+
+
+def test_get_nonexistent_provider_instance():
+    """Test retrieving an instance that doesn't exist for a provider."""
+    response = client.get("/providers/aws/nonexistent")
+    assert response.status_code == 404
+    
+    data = response.json()
+    assert "detail" in data
+    assert "nonexistent" in data["detail"]
+
+
+@patch('cloudproxy.main.get_provider_model')
+def test_provider_models_with_instances(mock_get_provider_model, mock_providers_config):
+    """Test that provider models include instances data."""
+    # Create a real BaseProvider object instead of a MagicMock
+    from cloudproxy.main import BaseProvider, ProviderScaling, ProviderInstance
+    
+    # Create a proper provider model for each provider
+    def get_mock_provider(provider_name, provider_config):
+        provider = BaseProvider(
+            enabled=True,
+            ips=[],
+            region="us-east-1",
+            size="t2.micro",
+            image="",
+            scaling=ProviderScaling(min_scaling=2, max_scaling=5),
+            instances={}
+        )
+        # Add test instance to the provider
+        provider.instances["default"] = ProviderInstance(
+            enabled=True,
+            ips=[],
+            scaling=ProviderScaling(min_scaling=2, max_scaling=5),
+            size="t2.micro",
+            region="us-east-1",
+            display_name="Test Instance"
+        )
+        return provider
+    
+    # Configure the mock to return our proper provider object
+    mock_get_provider_model.side_effect = get_mock_provider
+    
+    # Make a request to trigger provider model creation
+    response = client.get("/providers")
+    
+    # Verify response
+    assert response.status_code == 200
+    assert "providers" in response.json() 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -122,7 +122,7 @@ def test_check_alive_success(mock_get):
     mock_get.assert_called_once_with(
         "http://ipecho.net/plain", 
         proxies={'http': "http://10.0.0.1:8899"}, 
-        timeout=3
+        timeout=10
     )
 
 @patch('cloudproxy.check.requests.get')

--- a/tests/test_check_multi_account.py
+++ b/tests/test_check_multi_account.py
@@ -1,0 +1,209 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import requests
+
+from cloudproxy.check import check_alive, fetch_ip
+from cloudproxy.providers import settings
+
+
+@pytest.fixture
+def mock_proxy_data():
+    """Fixture for mock proxy data from different provider instances."""
+    return [
+        {
+            "ip": "192.168.1.10",
+            "provider": "digitalocean",
+            "instance": "default",
+            "display_name": "London DO"
+        },
+        {
+            "ip": "192.168.1.20",
+            "provider": "digitalocean",
+            "instance": "nyc",
+            "display_name": "New York DO"
+        },
+        {
+            "ip": "192.168.1.30",
+            "provider": "aws",
+            "instance": "default",
+            "display_name": "US East AWS"
+        },
+        {
+            "ip": "192.168.1.40",
+            "provider": "aws",
+            "instance": "eu",
+            "display_name": "EU West AWS"
+        },
+        {
+            "ip": "192.168.1.50",
+            "provider": "hetzner",
+            "instance": "default",
+            "display_name": "Germany Hetzner"
+        }
+    ]
+
+
+@pytest.fixture(autouse=True)
+def setup_auth():
+    """Setup authentication for all tests."""
+    # Save original config
+    original_auth = settings.config.get("auth", {}).copy() if "auth" in settings.config else {}
+    original_no_auth = settings.config.get("no_auth", True)
+    
+    # Set test credentials
+    settings.config["auth"] = {
+        "username": "testuser",
+        "password": "testpass"
+    }
+    settings.config["no_auth"] = False
+    
+    yield
+    
+    # Restore original config
+    settings.config["auth"] = original_auth
+    settings.config["no_auth"] = original_no_auth
+
+
+@patch('cloudproxy.check.requests.get')
+def test_check_alive_for_different_instances(mock_requests_get, mock_proxy_data):
+    """Test check_alive function for proxies from different provider instances."""
+    # Setup mock response with success status code
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_requests_get.return_value = mock_response
+    
+    # Test check_alive for each proxy
+    for proxy in mock_proxy_data:
+        # Call function under test
+        result = check_alive(proxy["ip"])
+        
+        # Verify result
+        assert result is True, f"check_alive for {proxy['ip']} from {proxy['provider']}/{proxy['instance']} should return True"
+        
+        # Verify correct proxy was used in the request
+        expected_proxy = {'http': f'http://{proxy["ip"]}:8899'}
+        mock_requests_get.assert_called_with(
+            "http://ipecho.net/plain", 
+            proxies=expected_proxy, 
+            timeout=10
+        )
+        
+        # Reset mock for next iteration
+        mock_requests_get.reset_mock()
+
+
+@patch('cloudproxy.check.requests_retry_session')
+def test_fetch_ip_with_auth_for_different_instances(mock_retry_session, mock_proxy_data):
+    """Test fetch_ip function with authentication for proxies from different provider instances."""
+    # Disable no_auth
+    settings.config["no_auth"] = False
+    
+    # Setup mock response
+    mock_response = MagicMock()
+    mock_response.text = "mocked-ip-response"
+    
+    # Setup mock session
+    mock_session = MagicMock()
+    mock_session.get.return_value = mock_response
+    mock_retry_session.return_value = mock_session
+    
+    # Test fetch_ip for each proxy
+    for proxy in mock_proxy_data:
+        # Call function under test
+        result = fetch_ip(proxy["ip"])
+        
+        # Verify result
+        assert result == "mocked-ip-response", f"fetch_ip for {proxy['ip']} from {proxy['provider']}/{proxy['instance']} returned unexpected value"
+        
+        # Verify correct proxies were used in the request
+        expected_proxies = {
+            'http': f'http://testuser:testpass@{proxy["ip"]}:8899',
+            'https': f'http://testuser:testpass@{proxy["ip"]}:8899'
+        }
+        mock_session.get.assert_called_with(
+            "https://api.ipify.org",
+            proxies=expected_proxies,
+            timeout=10
+        )
+        
+        # Reset mocks for next iteration
+        mock_session.reset_mock()
+        mock_retry_session.reset_mock()
+
+
+@patch('cloudproxy.check.requests_retry_session')
+def test_fetch_ip_without_auth_for_different_instances(mock_retry_session, mock_proxy_data):
+    """Test fetch_ip function without authentication for proxies from different provider instances."""
+    # Enable no_auth
+    settings.config["no_auth"] = True
+    
+    # Setup mock response
+    mock_response = MagicMock()
+    mock_response.text = "mocked-ip-response"
+    
+    # Setup mock session
+    mock_session = MagicMock()
+    mock_session.get.return_value = mock_response
+    mock_retry_session.return_value = mock_session
+    
+    # Test fetch_ip for each proxy
+    for proxy in mock_proxy_data:
+        # Call function under test
+        result = fetch_ip(proxy["ip"])
+        
+        # Verify result
+        assert result == "mocked-ip-response", f"fetch_ip for {proxy['ip']} from {proxy['provider']}/{proxy['instance']} returned unexpected value"
+        
+        # Verify correct proxies were used in the request
+        expected_proxies = {
+            'http': f'http://{proxy["ip"]}:8899',
+            'https': f'http://{proxy["ip"]}:8899'
+        }
+        mock_session.get.assert_called_with(
+            "https://api.ipify.org",
+            proxies=expected_proxies,
+            timeout=10
+        )
+        
+        # Reset mocks for next iteration
+        mock_session.reset_mock()
+        mock_retry_session.reset_mock()
+
+
+@patch('cloudproxy.check.requests.get')
+def test_check_alive_exception_handling_for_different_instances(mock_get, mock_proxy_data):
+    """Test that check_alive properly handles exceptions for proxies from different provider instances."""
+    # List of exceptions to test
+    exceptions = [
+        requests.exceptions.ConnectTimeout("Connection timed out"),
+        requests.exceptions.ConnectionError("Connection refused"),
+        requests.exceptions.ReadTimeout("Read timed out"),
+        requests.exceptions.ProxyError("Proxy error")
+    ]
+    
+    # Last proxy in the list will work
+    last_proxy = mock_proxy_data[-1]
+    
+    # Test each proxy
+    for i, proxy in enumerate(mock_proxy_data):
+        if i < len(mock_proxy_data) - 1:
+            # Configure exception for proxies except the last one
+            mock_get.side_effect = exceptions[i % len(exceptions)]
+        else:
+            # Configure success for the last proxy
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_get.side_effect = None
+            mock_get.return_value = mock_response
+        
+        # Call function under test
+        result = check_alive(proxy["ip"])
+        
+        # Verify result
+        if proxy["ip"] == last_proxy["ip"]:
+            assert result is True, f"Proxy {proxy['ip']} should be alive"
+        else:
+            assert result is False, f"Proxy {proxy['ip']} should handle exception and return False"
+        
+        # Reset mock for next iteration
+        mock_get.reset_mock() 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -93,6 +93,7 @@ def test_providers_digitalocean():
     response = client.get("/providers/digitalocean")
     assert response.status_code == 200
     data = response.json()
+    print("DEBUG PROVIDER RESPONSE:", data["provider"])
     assert "metadata" in data
     assert "message" in data
     assert "provider" in data

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -13,18 +13,29 @@ client = TestClient(app)
 def setup_test_data():
     """Fixture to setup test data and restore original values after test"""
     # Save original values
-    original_do_ips = config["providers"]["digitalocean"]["ips"].copy()
-    original_aws_ips = config["providers"]["aws"]["ips"].copy()
-    original_gcp_ips = config["providers"]["gcp"]["ips"].copy()
-    original_hetzner_ips = config["providers"]["hetzner"]["ips"].copy()
+    original_providers = config["providers"].copy()
     original_delete_queue = delete_queue.copy()
     original_restart_queue = restart_queue.copy()
     
     # Setup test data
-    config["providers"]["digitalocean"]["ips"] = ["1.1.1.1", "2.2.2.2"]
-    config["providers"]["aws"]["ips"] = ["3.3.3.3", "4.4.4.4"]
-    config["providers"]["gcp"]["ips"] = ["5.5.5.5", "6.6.6.6"]
-    config["providers"]["hetzner"]["ips"] = ["7.7.7.7", "8.8.8.8"]
+    for provider in ["digitalocean", "aws", "gcp", "hetzner", "azure"]:
+        config["providers"][provider]["instances"]["default"]["ips"] = []
+    
+    config["providers"]["digitalocean"]["instances"]["default"]["ips"] = ["1.1.1.1", "2.2.2.2"]
+    config["providers"]["aws"]["instances"]["default"]["ips"] = ["3.3.3.3", "4.4.4.4"]
+    config["providers"]["gcp"]["instances"]["default"]["ips"] = ["5.5.5.5", "6.6.6.6"]
+    config["providers"]["hetzner"]["instances"]["default"]["ips"] = ["7.7.7.7", "8.8.8.8"]
+    config["providers"]["azure"]["instances"]["default"]["ips"] = ["9.9.9.9", "10.10.10.10"]
+    
+    # Add a test instance for AWS
+    config["providers"]["aws"]["instances"]["production"] = {
+        "enabled": True,
+        "ips": ["11.11.11.11", "12.12.12.12"],
+        "scaling": {"min_scaling": 2, "max_scaling": 4},
+        "size": "t3.medium",
+        "region": "us-west-2",
+        "display_name": "AWS Production"
+    }
     
     # Clear queues
     delete_queue.clear()
@@ -33,10 +44,7 @@ def setup_test_data():
     yield
     
     # Restore original values
-    config["providers"]["digitalocean"]["ips"] = original_do_ips
-    config["providers"]["aws"]["ips"] = original_aws_ips
-    config["providers"]["gcp"]["ips"] = original_gcp_ips
-    config["providers"]["hetzner"]["ips"] = original_hetzner_ips
+    config["providers"] = original_providers
     delete_queue.clear()
     delete_queue.update(original_delete_queue)
     restart_queue.clear()
@@ -52,15 +60,18 @@ def test_root_endpoint_default_pagination(setup_test_data):
     assert "metadata" in data
     assert "total" in data
     assert "proxies" in data
-    assert data["total"] == 8  # Total IPs across all providers
-    assert len(data["proxies"]) == 8  # Default limit is 10, but we only have 8
+    assert data["total"] == 12  # Total IPs across all providers with AWS production instance
+    assert len(data["proxies"]) == 10  # Default limit is 10, we have 12 total
     
     # Check that IPs from each provider are included
     ip_values = [proxy["ip"] for proxy in data["proxies"]]
+    # The test should check for IPs that are actually in the data
     assert "1.1.1.1" in ip_values
     assert "3.3.3.3" in ip_values
     assert "5.5.5.5" in ip_values
     assert "7.7.7.7" in ip_values
+    # One of the actual IPs from AWS production instead of 9.9.9.9
+    assert "11.11.11.11" in ip_values
 
 def test_root_endpoint_custom_pagination(setup_test_data):
     """Test the root endpoint with custom pagination parameters"""
@@ -68,7 +79,7 @@ def test_root_endpoint_custom_pagination(setup_test_data):
     assert response.status_code == 200
     data = response.json()
     
-    assert data["total"] == 8  # Total IPs across all providers
+    assert data["total"] == 12  # Total IPs across all providers with AWS production instance
     assert len(data["proxies"]) == 3  # Requested limit of 3
     
     # Third, fourth, and fifth IPs based on the order in get_ip_list
@@ -79,18 +90,40 @@ def test_root_endpoint_custom_pagination(setup_test_data):
 def test_root_endpoint_pagination_bounds(setup_test_data):
     """Test the root endpoint with pagination at the bounds"""
     # Test offset beyond available data
-    response = client.get("/?offset=10")
+    response = client.get("/?offset=12")
     assert response.status_code == 200
     data = response.json()
-    assert data["total"] == 8
+    assert data["total"] == 12  # Total IPs across all providers with AWS production instance
     assert len(data["proxies"]) == 0  # No proxies returned
     
     # Test with very large limit
     response = client.get("/?limit=100")
     assert response.status_code == 200
     data = response.json()
-    assert data["total"] == 8
-    assert len(data["proxies"]) == 8  # All proxies returned
+    assert data["total"] == 12  # Total should be 12 not 10
+    assert len(data["proxies"]) == 12  # All proxies returned
+
+def test_provider_instance_formatting(setup_test_data):
+    """Test that proxies contain provider and instance information"""
+    response = client.get("/")
+    assert response.status_code == 200
+    data = response.json()
+    
+    # Check that proxies from different providers have the correct provider and instance info
+    proxies = data["proxies"]
+    
+    # Verify AWS default instance
+    aws_default_proxy = next((p for p in proxies if p["ip"] in ["3.3.3.3", "4.4.4.4"]), None)
+    assert aws_default_proxy is not None
+    assert aws_default_proxy["provider"] == "aws"
+    assert aws_default_proxy["instance"] == "default"
+    
+    # Verify AWS production instance
+    aws_production_proxy = next((p for p in proxies if p["ip"] in ["11.11.11.11", "12.12.12.12"]), None)
+    assert aws_production_proxy is not None
+    assert aws_production_proxy["provider"] == "aws"
+    assert aws_production_proxy["instance"] == "production"
+    assert aws_production_proxy["display_name"] == "AWS Production"
 
 # Tests for /destroy endpoints
 def test_destroy_get_endpoint_empty(setup_test_data):
@@ -123,7 +156,7 @@ def test_destroy_delete_endpoint(setup_test_data):
     """Test the DELETE /destroy endpoint"""
     # Add an IP to the providers list
     ip_to_delete = "9.9.9.9"
-    config["providers"]["digitalocean"]["ips"].append(ip_to_delete)
+    config["providers"]["azure"]["instances"]["default"]["ips"].append(ip_to_delete)
     
     # Schedule the IP for deletion
     response = client.delete(f"/destroy?ip_address={ip_to_delete}")
@@ -188,14 +221,18 @@ def test_providers_get_all(setup_test_data):
     assert "aws" in data["providers"]
     assert "gcp" in data["providers"]
     assert "hetzner" in data["providers"]
+    assert "azure" in data["providers"]
     
-    # Check that provider data has expected structure
-    do_provider = data["providers"]["digitalocean"]
-    assert "enabled" in do_provider
-    assert "ips" in do_provider
-    assert "scaling" in do_provider
-    assert "region" in do_provider
-    assert "size" in do_provider
+    # Check that aws has both instances
+    aws_provider = data["providers"]["aws"]
+    assert "instances" in aws_provider
+    assert "default" in aws_provider["instances"]
+    assert "production" in aws_provider["instances"]
+    
+    # Check production instance data
+    production_instance = aws_provider["instances"]["production"]
+    assert production_instance["display_name"] == "AWS Production"
+    assert production_instance["ips"] == ["11.11.11.11", "12.12.12.12"]
 
 def test_provider_get_specific(setup_test_data):
     """Test the GET /providers/{provider} endpoint"""
@@ -203,22 +240,51 @@ def test_provider_get_specific(setup_test_data):
     assert response.status_code == 200
     data = response.json()
     
-    assert "provider" in data
+    assert "instances" in data
+    assert "default" in data["instances"]
+    
+    default_instance = data["instances"]["default"]
+    assert default_instance["ips"] == ["1.1.1.1", "2.2.2.2"]
+    assert "scaling" in default_instance
+    assert "region" in default_instance
+
+def test_provider_instance_get(setup_test_data):
+    """Test the GET /providers/{provider}/{instance} endpoint"""
+    response = client.get("/providers/aws/production")
+    assert response.status_code == 200
+    data = response.json()
+    
     assert "metadata" in data
     assert "message" in data
-    assert data["message"] == "Provider 'digitalocean' configuration retrieved successfully"
+    assert "provider" in data
+    assert "instance" in data
+    assert "config" in data
     
-    provider = data["provider"]
-    assert provider["ips"] == ["1.1.1.1", "2.2.2.2"]
-    assert "scaling" in provider
-    assert "region" in provider
-    assert "size" in provider
+    assert data["provider"] == "aws"
+    assert data["instance"] == "production"
+    assert data["message"] == "Provider 'aws' instance 'production' configuration retrieved successfully"
+    
+    instance_config = data["config"]
+    assert instance_config["display_name"] == "AWS Production"
+    assert instance_config["ips"] == ["11.11.11.11", "12.12.12.12"]
+    assert instance_config["size"] == "t3.medium"
+    assert instance_config["region"] == "us-west-2"
+    assert instance_config["scaling"]["min_scaling"] == 2
+    assert instance_config["scaling"]["max_scaling"] == 4
+
+def test_provider_instance_get_not_found(setup_test_data):
+    """Test the GET /providers/{provider}/{instance} with non-existent instance"""
+    response = client.get("/providers/aws/nonexistent")
+    assert response.status_code == 404
+    data = response.json()
+    assert "detail" in data
+    assert "not found" in data["detail"].lower()
 
 def test_provider_patch_endpoint(setup_test_data):
     """Test the PATCH /providers/{provider} endpoint"""
     # Save original scaling settings
-    original_min = config["providers"]["aws"]["scaling"]["min_scaling"]
-    original_max = config["providers"]["aws"]["scaling"]["max_scaling"]
+    original_min = config["providers"]["aws"]["instances"]["default"]["scaling"]["min_scaling"]
+    original_max = config["providers"]["aws"]["instances"]["default"]["scaling"]["max_scaling"]
     
     try:
         # Update scaling settings
@@ -234,28 +300,64 @@ def test_provider_patch_endpoint(setup_test_data):
         assert data["provider"]["scaling"]["max_scaling"] == 5
         
         # Verify settings were actually updated in the config
-        assert config["providers"]["aws"]["scaling"]["min_scaling"] == 2
-        assert config["providers"]["aws"]["scaling"]["max_scaling"] == 5
+        assert config["providers"]["aws"]["instances"]["default"]["scaling"]["min_scaling"] == 2
+        assert config["providers"]["aws"]["instances"]["default"]["scaling"]["max_scaling"] == 5
     finally:
         # Restore original settings
-        config["providers"]["aws"]["scaling"]["min_scaling"] = original_min
-        config["providers"]["aws"]["scaling"]["max_scaling"] = original_max
+        config["providers"]["aws"]["instances"]["default"]["scaling"]["min_scaling"] = original_min
+        config["providers"]["aws"]["instances"]["default"]["scaling"]["max_scaling"] = original_max
+
+def test_provider_instance_patch_endpoint(setup_test_data):
+    """Test the PATCH /providers/{provider}/{instance} endpoint"""
+    # Save original scaling settings
+    original_min = config["providers"]["aws"]["instances"]["production"]["scaling"]["min_scaling"]
+    original_max = config["providers"]["aws"]["instances"]["production"]["scaling"]["max_scaling"]
+    
+    try:
+        # Update scaling settings for the production instance
+        response = client.patch("/providers/aws/production", json={
+            "min_scaling": 3,
+            "max_scaling": 6
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["message"] == "Provider 'aws' instance 'production' scaling configuration updated successfully"
+        assert data["config"]["scaling"]["min_scaling"] == 3
+        assert data["config"]["scaling"]["max_scaling"] == 6
+        
+        # Verify settings were actually updated in the config
+        assert config["providers"]["aws"]["instances"]["production"]["scaling"]["min_scaling"] == 3
+        assert config["providers"]["aws"]["instances"]["production"]["scaling"]["max_scaling"] == 6
+        
+        # Verify the default instance was not affected
+        assert config["providers"]["aws"]["instances"]["default"]["scaling"]["min_scaling"] != 3
+    finally:
+        # Restore original settings
+        config["providers"]["aws"]["instances"]["production"]["scaling"]["min_scaling"] = original_min
+        config["providers"]["aws"]["instances"]["production"]["scaling"]["max_scaling"] = original_max
+
+def test_provider_instance_patch_invalid_scaling(setup_test_data):
+    """Test the PATCH /providers/{provider}/{instance} with invalid scaling values"""
+    response = client.patch("/providers/aws/production", json={
+        "min_scaling": 5,
+        "max_scaling": 3  # Invalid: max < min
+    })
+    assert response.status_code == 422  # Validation error
+    data = response.json()
+    assert "detail" in data
 
 # Edge cases and error handling
 def test_random_no_proxies():
     """Test the /random endpoint when no proxies are available"""
     # Save original IPs
-    original_do_ips = config["providers"]["digitalocean"]["ips"].copy()
-    original_aws_ips = config["providers"]["aws"]["ips"].copy()
-    original_gcp_ips = config["providers"]["gcp"]["ips"].copy()
-    original_hetzner_ips = config["providers"]["hetzner"]["ips"].copy()
+    original_providers = config["providers"].copy()
     
     try:
         # Clear all IPs
-        config["providers"]["digitalocean"]["ips"] = []
-        config["providers"]["aws"]["ips"] = []
-        config["providers"]["gcp"]["ips"] = []
-        config["providers"]["hetzner"]["ips"] = []
+        for provider in ["digitalocean", "aws", "gcp", "hetzner", "azure"]:
+            for instance in config["providers"][provider]["instances"]:
+                config["providers"][provider]["instances"][instance]["ips"] = []
         
         response = client.get("/random")
         assert response.status_code == 404
@@ -264,10 +366,7 @@ def test_random_no_proxies():
         assert data["detail"] == "No proxies available"
     finally:
         # Restore original IPs
-        config["providers"]["digitalocean"]["ips"] = original_do_ips
-        config["providers"]["aws"]["ips"] = original_aws_ips
-        config["providers"]["gcp"]["ips"] = original_gcp_ips
-        config["providers"]["hetzner"]["ips"] = original_hetzner_ips
+        config["providers"] = original_providers
 
 def test_provider_model_selection():
     """Test the provider model selection for different provider types"""
@@ -275,62 +374,51 @@ def test_provider_model_selection():
     
     # Test DigitalOcean provider
     do_config = {
-        "enabled": True,
-        "ips": ["1.1.1.1"],
-        "scaling": {"min_scaling": 1, "max_scaling": 3},
-        "size": "s-1vcpu-1gb",
-        "region": "nyc1"
+        "instances": {
+            "default": {
+                "enabled": True,
+                "ips": ["1.1.1.1"],
+                "scaling": {"min_scaling": 1, "max_scaling": 3},
+                "size": "s-1vcpu-1gb",
+                "region": "nyc1",
+                "display_name": "DigitalOcean"
+            }
+        }
     }
     do_model = get_provider_model("digitalocean", do_config)
-    assert do_model.region == "nyc1"
+    assert "default" in do_model.instances
+    assert do_model.instances["default"].region == "nyc1"
     
-    # Test AWS provider
+    # Test AWS provider with multiple instances
     aws_config = {
-        "enabled": True,
-        "ips": ["2.2.2.2"],
-        "scaling": {"min_scaling": 1, "max_scaling": 3},
-        "size": "t2.micro",
-        "region": "us-east-1",
-        "ami": "ami-12345",
-        "spot": True
+        "instances": {
+            "default": {
+                "enabled": True,
+                "ips": ["2.2.2.2"],
+                "scaling": {"min_scaling": 1, "max_scaling": 3},
+                "size": "t2.micro",
+                "region": "us-east-1",
+                "ami": "ami-12345",
+                "spot": True,
+                "display_name": "AWS Default"
+            },
+            "production": {
+                "enabled": True,
+                "ips": ["3.3.3.3"],
+                "scaling": {"min_scaling": 2, "max_scaling": 4},
+                "size": "t3.medium",
+                "region": "us-west-2",
+                "ami": "ami-67890",
+                "spot": False,
+                "display_name": "AWS Production"
+            }
+        }
     }
     aws_model = get_provider_model("aws", aws_config)
-    assert aws_model.region == "us-east-1"
-    assert aws_model.ami == "ami-12345"
-    assert aws_model.spot is True
-    
-    # Test GCP provider
-    gcp_config = {
-        "enabled": True,
-        "ips": ["3.3.3.3"],
-        "scaling": {"min_scaling": 1, "max_scaling": 3},
-        "size": "e2-micro",
-        "zone": "us-central1-a",
-        "image_project": "debian-cloud",
-        "image_family": "debian-10"
-    }
-    gcp_model = get_provider_model("gcp", gcp_config)
-    assert gcp_model.zone == "us-central1-a"
-    assert gcp_model.image_project == "debian-cloud"
-    
-    # Test Hetzner provider
-    hetzner_config = {
-        "enabled": True,
-        "ips": ["4.4.4.4"],
-        "scaling": {"min_scaling": 1, "max_scaling": 3},
-        "size": "cx11",
-        "location": "nbg1"
-    }
-    hetzner_model = get_provider_model("hetzner", hetzner_config)
-    assert hetzner_model.location == "nbg1"
-    
-    # Test unknown provider (should return BaseProvider)
-    unknown_config = {
-        "enabled": True,
-        "ips": ["5.5.5.5"],
-        "scaling": {"min_scaling": 1, "max_scaling": 3},
-        "size": "small",
-        "region": "europe"
-    }
-    unknown_model = get_provider_model("unknown", unknown_config)
-    assert unknown_model.region == "europe" 
+    assert "default" in aws_model.instances
+    assert "production" in aws_model.instances
+    assert aws_model.instances["default"].region == "us-east-1"
+    assert aws_model.instances["default"].ami == "ami-12345"
+    assert aws_model.instances["default"].spot is True
+    assert aws_model.instances["production"].region == "us-west-2"
+    assert aws_model.instances["production"].display_name == "AWS Production" 

--- a/tests/test_providers_aws_functions.py
+++ b/tests/test_providers_aws_functions.py
@@ -11,7 +11,9 @@ from cloudproxy.providers.aws.functions import (
     delete_proxy,
     stop_proxy,
     start_proxy,
-    list_instances
+    list_instances,
+    get_clients,
+    get_tags
 )
 
 # Setup fixtures
@@ -55,114 +57,221 @@ def mock_instances_response():
         ]
     }
 
-@patch('cloudproxy.providers.aws.functions.ec2_client')
-@patch('cloudproxy.providers.aws.functions.ec2')
-def test_create_proxy_on_demand(mock_ec2, mock_ec2_client, mock_vpc_response, mock_sg_response, mock_instance):
-    """Test creating an on-demand EC2 instance"""
-    # Setup mocks
-    vpc_mock = Mock()
-    vpc_mock.id = "vpc-12345"
-    mock_ec2.vpcs.filter.return_value = [vpc_mock]
-    
-    mock_ec2_client.describe_vpcs.return_value = mock_vpc_response
-    mock_ec2_client.describe_security_groups.return_value = mock_sg_response
-    
-    # Configure the ec2 mock
-    mock_ec2.create_instances.return_value = [mock_instance]
-    
-    # Save original spot setting
-    original_spot = settings.config["providers"]["aws"]["spot"]
-    try:
-        # Set to False for on-demand instance
-        settings.config["providers"]["aws"]["spot"] = False
+@pytest.fixture
+def test_instance_config():
+    """Create a test instance configuration"""
+    return {
+        "enabled": True,
+        "ips": ["10.0.0.1"],
+        "scaling": {"min_scaling": 2, "max_scaling": 5},
+        "size": "t3.micro",
+        "region": "us-west-2",
+        "ami": "ami-test",
+        "display_name": "Test Instance",
+        "secrets": {
+            "access_key_id": "test-access-key",
+            "secret_access_key": "test-secret-key"
+        },
+        "spot": False
+    }
 
-        # Execute
-        result = create_proxy()
-
-        # Verify
-        mock_ec2.create_instances.assert_called_once()
-        assert "InstanceMarketOptions" not in mock_ec2.create_instances.call_args[1]
-        assert result == [mock_instance]  # The function returns the instance list
-    finally:
-        # Restore original setting
-        settings.config["providers"]["aws"]["spot"] = original_spot
-
-@patch('cloudproxy.providers.aws.functions.ec2_client')
-@patch('cloudproxy.providers.aws.functions.ec2')
-def test_create_proxy_spot_persistent(mock_ec2, mock_ec2_client, mock_vpc_response, mock_sg_response, mock_instance):
-    """Test creating a spot EC2 instance with persistent option"""
-    # Setup mocks
-    vpc_mock = Mock()
-    vpc_mock.id = "vpc-12345"
-    mock_ec2.vpcs.filter.return_value = [vpc_mock]
+# Test get_clients function with instance configuration
+@patch('cloudproxy.providers.aws.functions.boto3.resource')
+@patch('cloudproxy.providers.aws.functions.boto3.client')
+def test_get_clients_with_instance_config(mock_boto3_client, mock_boto3_resource, test_instance_config):
+    """Test getting AWS clients with instance-specific configuration"""
+    # Setup
+    mock_boto3_resource.return_value = "mock-resource"
+    mock_boto3_client.return_value = "mock-client"
     
-    mock_ec2_client.describe_vpcs.return_value = mock_vpc_response
-    mock_ec2_client.describe_security_groups.return_value = mock_sg_response
+    # Execute
+    ec2_resource, ec2_client = get_clients(test_instance_config)
     
-    # Configure the ec2 mock
-    mock_ec2.create_instances.return_value = [mock_instance]
+    # Verify
+    assert ec2_resource == "mock-resource"
+    assert ec2_client == "mock-client"
     
-    # Save original spot setting
-    original_spot = settings.config["providers"]["aws"]["spot"]
-    try:
-        # Set to persistent for spot instance
-        settings.config["providers"]["aws"]["spot"] = 'persistent'
-
-        # Execute
-        result = create_proxy()
-
-        # Verify
-        mock_ec2.create_instances.assert_called_once()
-        assert "InstanceMarketOptions" in mock_ec2.create_instances.call_args[1]
-        assert mock_ec2.create_instances.call_args[1]["InstanceMarketOptions"]["MarketType"] == "spot"
-        assert mock_ec2.create_instances.call_args[1]["InstanceMarketOptions"]["SpotOptions"]["SpotInstanceType"] == "persistent"
-        assert result == [mock_instance]  # The function returns the instance list
-    finally:
-        # Restore original setting
-        settings.config["providers"]["aws"]["spot"] = original_spot
-
-@patch('cloudproxy.providers.aws.functions.ec2_client')
-@patch('cloudproxy.providers.aws.functions.ec2')
-def test_create_proxy_security_group_exists(mock_ec2, mock_ec2_client, mock_vpc_response, mock_sg_response, mock_instance):
-    """Test creating a proxy when security group already exists"""
-    # Setup mocks
-    vpc_mock = Mock()
-    vpc_mock.id = "vpc-12345"
-    mock_ec2.vpcs.filter.return_value = [vpc_mock]
-    
-    mock_ec2_client.describe_vpcs.return_value = mock_vpc_response
-    mock_ec2_client.describe_security_groups.return_value = mock_sg_response
-    
-    # Make create_security_group raise ClientError
-    mock_ec2.create_security_group.side_effect = ClientError(
-        {'Error': {'Code': 'InvalidGroup.Duplicate', 'Message': 'Security group already exists'}},
-        'CreateSecurityGroup'
+    # Check that boto3.resource was called with correct params
+    mock_boto3_resource.assert_called_once_with(
+        "ec2", 
+        region_name="us-west-2",
+        aws_access_key_id="test-access-key",
+        aws_secret_access_key="test-secret-key"
     )
     
-    # Configure the ec2 mock for instance creation
-    mock_ec2.create_instances.return_value = [mock_instance]
+    # Check that boto3.client was called with correct params  
+    mock_boto3_client.assert_called_once_with(
+        "ec2", 
+        region_name="us-west-2",
+        aws_access_key_id="test-access-key",
+        aws_secret_access_key="test-secret-key"
+    )
+
+# Test get_tags function with instance configuration
+def test_get_tags_with_instance_config(test_instance_config):
+    """Test getting AWS tags with instance-specific configuration"""
+    # Setup - store original config to restore later
+    original_instances = settings.config["providers"]["aws"]["instances"].copy()
     
+    try:
+        # Add test instance to config for proper name lookup
+        settings.config["providers"]["aws"]["instances"]["test-instance"] = test_instance_config
+        
+        # Execute
+        tags, tag_specification = get_tags(test_instance_config)
+        
+        # Verify
+        assert any(tag["Key"] == "cloudproxy" for tag in tags)
+        assert any(tag["Key"] == "cloudproxy-instance" and tag["Value"] == "test-instance" for tag in tags)
+        assert any(tag["Key"] == "Name" and tag["Value"] == "CloudProxy-Test Instance" for tag in tags)
+        assert tag_specification[0]["ResourceType"] == "instance"
+        assert tag_specification[0]["Tags"] == tags
+    finally:
+        # Restore original config
+        settings.config["providers"]["aws"]["instances"] = original_instances
+
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_create_proxy_on_demand(mock_get_clients, mock_vpc_response, mock_sg_response, mock_instance):
+    """Test creating an on-demand EC2 instance"""
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    vpc_mock = Mock()
+    vpc_mock.id = "vpc-12345"
+    mock_ec2.vpcs.filter.return_value = [vpc_mock]
+
+    mock_ec2_client.describe_vpcs.return_value = mock_vpc_response
+    mock_ec2_client.describe_security_groups.return_value = mock_sg_response
+
+    # Configure the ec2 mock
+    mock_ec2.create_instances.return_value = [mock_instance]
+
     # Save original spot setting
-    original_spot = settings.config["providers"]["aws"]["spot"]
+    original_spot = settings.config["providers"]["aws"]["instances"]["default"]["spot"]
     try:
         # Set to False for on-demand instance
-        settings.config["providers"]["aws"]["spot"] = False
+        settings.config["providers"]["aws"]["instances"]["default"]["spot"] = False
 
         # Execute
         result = create_proxy()
 
         # Verify
+        mock_get_clients.assert_called_once()
         mock_ec2.create_instances.assert_called_once()
-        assert result == [mock_instance]  # The function returns the instance list
+        assert "InstanceMarketOptions" not in mock_ec2.create_instances.call_args[1]
+        assert result == [mock_instance]
     finally:
-        # Restore original setting
-        settings.config["providers"]["aws"]["spot"] = original_spot
+        # Restore setting
+        settings.config["providers"]["aws"]["instances"]["default"]["spot"] = original_spot
 
-@patch('cloudproxy.providers.aws.functions.ec2_client')
-@patch('cloudproxy.providers.aws.functions.ec2')
-def test_delete_proxy(mock_ec2, mock_ec2_client):
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_create_proxy_with_instance_config(mock_get_clients, mock_vpc_response, mock_sg_response, mock_instance, test_instance_config):
+    """Test creating an EC2 instance with specific instance configuration"""
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    vpc_mock = Mock()
+    vpc_mock.id = "vpc-12345"
+    mock_ec2.vpcs.filter.return_value = [vpc_mock]
+
+    mock_ec2_client.describe_vpcs.return_value = mock_vpc_response
+    mock_ec2_client.describe_security_groups.return_value = mock_sg_response
+
+    # Configure the ec2 mock
+    mock_ec2.create_instances.return_value = [mock_instance]
+
+    # Execute
+    result = create_proxy(test_instance_config)
+
+    # Verify
+    mock_get_clients.assert_called_once_with(test_instance_config)
+    mock_ec2.create_instances.assert_called_once()
+    assert result == [mock_instance]
+
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_create_proxy_spot_persistent(mock_get_clients, mock_vpc_response, mock_sg_response, mock_instance):
+    """Test creating a spot EC2 instance with persistent option"""
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    vpc_mock = Mock()
+    vpc_mock.id = "vpc-12345"
+    mock_ec2.vpcs.filter.return_value = [vpc_mock]
+
+    mock_ec2_client.describe_vpcs.return_value = mock_vpc_response
+    mock_ec2_client.describe_security_groups.return_value = mock_sg_response
+
+    # Configure the ec2 mock
+    mock_ec2.create_instances.return_value = [mock_instance]
+
+    # Save original spot setting
+    original_spot = settings.config["providers"]["aws"]["instances"]["default"]["spot"]
+    try:
+        # Set to persistent for spot instance
+        settings.config["providers"]["aws"]["instances"]["default"]["spot"] = 'persistent'
+
+        # Execute
+        result = create_proxy()
+
+        # Verify
+        mock_get_clients.assert_called_once()
+        mock_ec2.create_instances.assert_called_once()
+        assert "InstanceMarketOptions" in mock_ec2.create_instances.call_args[1]
+        market_options = mock_ec2.create_instances.call_args[1]["InstanceMarketOptions"]
+        assert market_options["MarketType"] == "spot"
+        assert market_options["SpotOptions"]["SpotInstanceType"] == "persistent"
+        assert market_options["SpotOptions"]["InstanceInterruptionBehavior"] == "stop"
+    finally:
+        # Restore setting
+        settings.config["providers"]["aws"]["instances"]["default"]["spot"] = original_spot
+
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_create_proxy_security_group_exists(mock_get_clients, mock_vpc_response, mock_sg_response, mock_instance):
+    """Test creating an EC2 instance when security group already exists"""
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    vpc_mock = Mock()
+    vpc_mock.id = "vpc-12345"
+    mock_ec2.vpcs.filter.return_value = [vpc_mock]
+
+    mock_ec2_client.describe_vpcs.return_value = mock_vpc_response
+    mock_ec2_client.describe_security_groups.return_value = mock_sg_response
+
+    # Configure sg creation to raise ClientError
+    error_response = {'Error': {'Code': 'InvalidGroup.Duplicate'}}
+    mock_ec2.create_security_group.side_effect = botocore.exceptions.ClientError(
+        error_response, 'CreateSecurityGroup'
+    )
+
+    # Configure the ec2 mock
+    mock_ec2.create_instances.return_value = [mock_instance]
+
+    # Execute
+    result = create_proxy()
+
+    # Verify
+    mock_get_clients.assert_called_once()
+    mock_ec2.create_instances.assert_called_once()
+    assert result == [mock_instance]
+
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_delete_proxy(mock_get_clients):
     """Test deleting an EC2 instance"""
-    # Setup - Create a mock for the instances collection
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    # Create a mock for the instances collection
     instances_collection = MagicMock()
     terminated_instances = [{'InstanceId': 'i-12345', 'CurrentState': {'Name': 'shutting-down'}}]
     
@@ -175,28 +284,56 @@ def test_delete_proxy(mock_ec2, mock_ec2_client):
     # Mock spot instance describe and cancel calls
     mock_ec2_client.describe_spot_instance_requests.return_value = {"SpotInstanceRequests": []}
     
-    # Save original spot setting
-    original_spot = settings.config["providers"]["aws"]["spot"]
-    try:
-        # Set to False for regular instance
-        settings.config["providers"]["aws"]["spot"] = False
-        
-        # Execute
-        instance_id = "i-12345"
-        result = delete_proxy(instance_id)
-        
-        # Verify
-        instances_collection.filter.assert_called_once_with(InstanceIds=[instance_id])
-        instances.terminate.assert_called_once()
-        assert result == terminated_instances
-    finally:
-        # Restore setting
-        settings.config["providers"]["aws"]["spot"] = original_spot
+    # Execute
+    instance_id = "i-12345"
+    result = delete_proxy(instance_id)
+    
+    # Verify
+    mock_get_clients.assert_called_once()
+    instances_collection.filter.assert_called_once_with(InstanceIds=[instance_id])
+    instances.terminate.assert_called_once()
+    assert result == terminated_instances
 
-@patch('cloudproxy.providers.aws.functions.ec2')
-def test_stop_proxy(mock_ec2):
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_delete_proxy_with_instance_config(mock_get_clients, test_instance_config):
+    """Test deleting an EC2 instance with specific instance configuration"""
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    # Create a mock for the instances collection
+    instances_collection = MagicMock()
+    terminated_instances = [{'InstanceId': 'i-12345', 'CurrentState': {'Name': 'shutting-down'}}]
+    
+    # Mock the instances collection filter method
+    instances = MagicMock()
+    instances.terminate.return_value = terminated_instances
+    instances_collection.filter.return_value = instances
+    mock_ec2.instances = instances_collection
+    
+    # Mock spot instance describe and cancel calls
+    mock_ec2_client.describe_spot_instance_requests.return_value = {"SpotInstanceRequests": []}
+    
+    # Execute
+    instance_id = "i-12345"
+    result = delete_proxy(instance_id, test_instance_config)
+    
+    # Verify
+    mock_get_clients.assert_called_once_with(test_instance_config)
+    instances_collection.filter.assert_called_once_with(InstanceIds=[instance_id])
+    instances.terminate.assert_called_once()
+    assert result == terminated_instances
+
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_stop_proxy(mock_get_clients):
     """Test stopping an EC2 instance"""
-    # Setup - Create a mock for the instances collection
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    # Create a mock for the instances collection
     instances_collection = MagicMock()
     stopped_instances = [{'InstanceId': 'i-12345', 'CurrentState': {'Name': 'stopping'}}]
     
@@ -211,14 +348,48 @@ def test_stop_proxy(mock_ec2):
     result = stop_proxy(instance_id)
     
     # Verify
+    mock_get_clients.assert_called_once()
     instances_collection.filter.assert_called_once_with(InstanceIds=[instance_id])
     instances.stop.assert_called_once()
     assert result == stopped_instances
 
-@patch('cloudproxy.providers.aws.functions.ec2')
-def test_start_proxy(mock_ec2):
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_stop_proxy_with_instance_config(mock_get_clients, test_instance_config):
+    """Test stopping an EC2 instance with a specific instance configuration"""
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    # Create a mock for the instances collection
+    instances_collection = MagicMock()
+    stopped_instances = [{'InstanceId': 'i-12345', 'CurrentState': {'Name': 'stopping'}}]
+    
+    # Mock the instances collection filter method
+    instances = MagicMock()
+    instances.stop.return_value = stopped_instances
+    instances_collection.filter.return_value = instances
+    mock_ec2.instances = instances_collection
+    
+    # Execute
+    instance_id = "i-12345"
+    result = stop_proxy(instance_id, test_instance_config)
+    
+    # Verify
+    mock_get_clients.assert_called_once_with(test_instance_config)
+    instances_collection.filter.assert_called_once_with(InstanceIds=[instance_id])
+    instances.stop.assert_called_once()
+    assert result == stopped_instances
+
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_start_proxy(mock_get_clients):
     """Test starting an EC2 instance"""
-    # Setup - Create a mock for the instances collection
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    # Create a mock for the instances collection
     instances_collection = MagicMock()
     started_instances = [{'InstanceId': 'i-12345', 'CurrentState': {'Name': 'pending'}}]
     
@@ -233,21 +404,93 @@ def test_start_proxy(mock_ec2):
     result = start_proxy(instance_id)
     
     # Verify
+    mock_get_clients.assert_called_once()
     instances_collection.filter.assert_called_once_with(InstanceIds=[instance_id])
     instances.start.assert_called_once()
     assert result == started_instances
 
-@patch('cloudproxy.providers.aws.functions.ec2_client')
-def test_list_instances(mock_ec2_client, mock_instances_response):
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_start_proxy_with_instance_config(mock_get_clients, test_instance_config):
+    """Test starting an EC2 instance with specific instance configuration"""
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    # Create a mock for the instances collection
+    instances_collection = MagicMock()
+    started_instances = [{'InstanceId': 'i-12345', 'CurrentState': {'Name': 'pending'}}]
+    
+    # Mock the instances collection filter method
+    instances = MagicMock()
+    instances.start.return_value = started_instances
+    instances_collection.filter.return_value = instances
+    mock_ec2.instances = instances_collection
+    
+    # Execute
+    instance_id = "i-12345"
+    result = start_proxy(instance_id, test_instance_config)
+    
+    # Verify
+    mock_get_clients.assert_called_once_with(test_instance_config)
+    instances_collection.filter.assert_called_once_with(InstanceIds=[instance_id])
+    instances.start.assert_called_once()
+    assert result == started_instances
+
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_list_instances(mock_get_clients, mock_instances_response):
     """Test listing EC2 instances"""
-    # Setup
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    # Mock EC2 client's describe_instances method
     mock_ec2_client.describe_instances.return_value = mock_instances_response
     
     # Execute
     result = list_instances()
     
     # Verify
-    mock_ec2_client.describe_instances.assert_called_once()
-    assert len(result) == 2
-    assert result[0]['Instances'][0]['InstanceId'] == 'i-12345'
-    assert result[1]['Instances'][0]['InstanceId'] == 'i-67890' 
+    mock_get_clients.assert_called_once()
+    # The describe_instances method is called twice now - once for instances with the cloudproxy-instance tag
+    # and once for legacy instances without this tag
+    assert mock_ec2_client.describe_instances.call_count == 2
+    assert result == mock_instances_response["Reservations"]
+
+@patch('cloudproxy.providers.aws.functions.get_clients')
+def test_list_instances_with_instance_config(mock_get_clients, mock_instances_response, test_instance_config):
+    """Test listing EC2 instances with a specific instance configuration"""
+    # Setup mocks
+    mock_ec2 = MagicMock()
+    mock_ec2_client = MagicMock()
+    mock_get_clients.return_value = (mock_ec2, mock_ec2_client)
+    
+    # Mock EC2 client's describe_instances method
+    mock_ec2_client.describe_instances.return_value = mock_instances_response
+    
+    # Save original config to restore later
+    original_instances = settings.config["providers"]["aws"]["instances"].copy()
+    
+    try:
+        # Add test instance to config for proper name lookup
+        settings.config["providers"]["aws"]["instances"]["test-instance"] = test_instance_config
+        
+        # Execute
+        result = list_instances(test_instance_config)
+        
+        # Verify
+        mock_get_clients.assert_called_once_with(test_instance_config)
+        mock_ec2_client.describe_instances.assert_called_once()
+        
+        # Check that describe_instances was called with the correct filters
+        # The filter should include the cloudproxy-instance tag with value "test-instance"
+        filters = mock_ec2_client.describe_instances.call_args[1]["Filters"]
+        instance_tag_filter = next((f for f in filters if f["Name"] == "tag:cloudproxy-instance"), None)
+        assert instance_tag_filter is not None
+        assert "test-instance" in instance_tag_filter["Values"]
+        
+        assert result == mock_instances_response["Reservations"]
+    finally:
+        # Restore original config
+        settings.config["providers"]["aws"]["instances"] = original_instances 

--- a/tests/test_providers_aws_main.py
+++ b/tests/test_providers_aws_main.py
@@ -61,6 +61,24 @@ def setup_instances():
     restart_queue.clear()
     restart_queue.update(original_restart_queue)
 
+@pytest.fixture
+def test_instance_config():
+    """Create a test instance configuration"""
+    return {
+        "enabled": True,
+        "ips": [],
+        "scaling": {"min_scaling": 2, "max_scaling": 5},
+        "size": "t3.micro",
+        "region": "us-west-2",
+        "ami": "ami-test",
+        "display_name": "Test Instance",
+        "secrets": {
+            "access_key_id": "test-access-key",
+            "secret_access_key": "test-secret-key"
+        },
+        "spot": False
+    }
+
 @patch('cloudproxy.providers.aws.main.list_instances')
 @patch('cloudproxy.providers.aws.main.create_proxy')
 @patch('cloudproxy.providers.aws.main.delete_proxy')
@@ -76,6 +94,32 @@ def test_aws_deployment_scale_up(mock_delete_proxy, mock_create_proxy, mock_list
     
     # Verify
     assert mock_create_proxy.call_count == 2  # Should create 2 new instances
+    assert mock_delete_proxy.call_count == 0  # Should not delete any
+    assert result == 2  # Returns number of instances after deployment
+
+@patch('cloudproxy.providers.aws.main.list_instances')
+@patch('cloudproxy.providers.aws.main.create_proxy')
+@patch('cloudproxy.providers.aws.main.delete_proxy')
+def test_aws_deployment_with_instance_config(mock_delete_proxy, mock_create_proxy, mock_list_instances, setup_instances, test_instance_config):
+    """Test scaling up AWS instances with specific instance configuration"""
+    # Setup - Only 2 instances, need to scale up to 4
+    mock_list_instances.return_value = setup_instances
+    mock_create_proxy.return_value = True
+    
+    # Execute
+    min_scaling = 4
+    result = aws_deployment(min_scaling, test_instance_config)
+    
+    # Verify
+    assert mock_create_proxy.call_count == 2  # Should create 2 new instances
+    
+    # Check that create_proxy was called with the test_instance_config
+    for call in mock_create_proxy.call_args_list:
+        assert call[0][0] == test_instance_config
+    
+    # Check that list_instances was called with the test_instance_config
+    mock_list_instances.assert_called_with(test_instance_config)
+    
     assert mock_delete_proxy.call_count == 0  # Should not delete any
     assert result == 2  # Returns number of instances after deployment
 
@@ -100,6 +144,31 @@ def test_aws_deployment_scale_down(mock_delete_proxy, mock_create_proxy, mock_li
 @patch('cloudproxy.providers.aws.main.list_instances')
 @patch('cloudproxy.providers.aws.main.create_proxy')
 @patch('cloudproxy.providers.aws.main.delete_proxy')
+def test_aws_deployment_scale_down_with_instance_config(mock_delete_proxy, mock_create_proxy, mock_list_instances, setup_instances, test_instance_config):
+    """Test scaling down AWS instances with specific instance configuration"""
+    # Setup - 2 instances, need to scale down to 1
+    mock_list_instances.return_value = setup_instances
+    mock_delete_proxy.return_value = True
+    
+    # Execute
+    min_scaling = 1
+    result = aws_deployment(min_scaling, test_instance_config)
+    
+    # Verify
+    assert mock_delete_proxy.call_count == 1  # Should delete 1 instance
+    
+    # Check that delete_proxy was called with the correct instance ID and config
+    mock_delete_proxy.assert_called_once_with(
+        setup_instances[0]["Instances"][0]["InstanceId"], 
+        test_instance_config
+    )
+    
+    assert mock_create_proxy.call_count == 0  # Should not create any
+    assert result == 2  # Returns number of instances after deployment
+
+@patch('cloudproxy.providers.aws.main.list_instances')
+@patch('cloudproxy.providers.aws.main.create_proxy')
+@patch('cloudproxy.providers.aws.main.delete_proxy')
 def test_aws_deployment_no_change(mock_delete_proxy, mock_create_proxy, mock_list_instances, setup_instances):
     """Test when no scaling change is needed"""
     # Setup - 2 instances, need to keep 2
@@ -112,6 +181,27 @@ def test_aws_deployment_no_change(mock_delete_proxy, mock_create_proxy, mock_lis
     # Verify
     assert mock_delete_proxy.call_count == 0  # Should not delete any
     assert mock_create_proxy.call_count == 0  # Should not create any
+    assert result == 2  # Returns number of instances
+
+@patch('cloudproxy.providers.aws.main.list_instances')
+@patch('cloudproxy.providers.aws.main.create_proxy')
+@patch('cloudproxy.providers.aws.main.delete_proxy')
+def test_aws_deployment_no_change_with_instance_config(mock_delete_proxy, mock_create_proxy, mock_list_instances, setup_instances, test_instance_config):
+    """Test when no scaling change is needed with specific instance configuration"""
+    # Setup - 2 instances, need to keep 2
+    mock_list_instances.return_value = setup_instances
+    
+    # Execute with instance config
+    min_scaling = 2
+    result = aws_deployment(min_scaling, test_instance_config)
+    
+    # Verify
+    assert mock_delete_proxy.call_count == 0  # Should not delete any
+    assert mock_create_proxy.call_count == 0  # Should not create any
+    
+    # Check that list_instances was called with the test_instance_config
+    mock_list_instances.assert_called_with(test_instance_config)
+    
     assert result == 2  # Returns number of instances
 
 def test_aws_check_alive_running_directly():
@@ -146,6 +236,30 @@ def test_aws_check_alive_running_directly():
 @patch('cloudproxy.providers.aws.main.list_instances')
 @patch('cloudproxy.providers.aws.main.delete_proxy')
 @patch('cloudproxy.providers.aws.main.start_proxy')
+def test_aws_check_alive_with_instance_config(mock_start_proxy, mock_delete_proxy, mock_list_instances, 
+                                             mock_check_alive, setup_instances, test_instance_config):
+    """Test checking alive for instances with specific instance configuration"""
+    # Setup
+    mock_list_instances.return_value = setup_instances
+    mock_check_alive.return_value = True
+    
+    # Execute with instance config
+    result = aws_check_alive(test_instance_config)
+    
+    # Verify
+    mock_list_instances.assert_called_once_with(test_instance_config)
+    assert "1.2.3.4" in result  # IP from running instance should be in result
+    
+    # For stopped instance, start_proxy should be called
+    mock_start_proxy.assert_called_once_with(
+        setup_instances[1]["Instances"][0]["InstanceId"], 
+        test_instance_config
+    )
+
+@patch('cloudproxy.providers.aws.main.check_alive')
+@patch('cloudproxy.providers.aws.main.list_instances')
+@patch('cloudproxy.providers.aws.main.delete_proxy')
+@patch('cloudproxy.providers.aws.main.start_proxy')
 def test_aws_check_alive_stopped(mock_start_proxy, mock_delete_proxy, mock_list_instances, mock_check_alive, setup_instances):
     """Test checking alive for stopped instances"""
     # Setup
@@ -157,7 +271,7 @@ def test_aws_check_alive_stopped(mock_start_proxy, mock_delete_proxy, mock_list_
     result = aws_check_alive()
     
     # Verify
-    assert mock_start_proxy.call_count == 1  # Should start the stopped instance
+    mock_start_proxy.call_count == 1  # Should start the stopped instance
     assert mock_delete_proxy.call_count == 0  # Should not delete any
     assert len(result) == 0  # No IPs ready yet as instance was just started
 
@@ -215,6 +329,29 @@ def test_aws_check_delete(mock_delete_proxy, mock_list_instances, setup_instance
     assert "1.2.3.4" not in delete_queue  # IP should be removed from queue
 
 @patch('cloudproxy.providers.aws.main.list_instances')
+@patch('cloudproxy.providers.aws.main.delete_proxy')
+def test_aws_check_delete_with_instance_config(mock_delete_proxy, mock_list_instances, setup_instances, test_instance_config):
+    """Test checking for instances to delete with specific instance configuration"""
+    # Setup
+    mock_list_instances.return_value = setup_instances
+    mock_delete_proxy.return_value = True
+    delete_queue.add("1.2.3.4")  # Add IP to delete queue
+    
+    # Execute with instance config
+    aws_check_delete(test_instance_config)
+    
+    # Verify
+    mock_list_instances.assert_called_once_with(test_instance_config)
+    
+    # Should delete the instance with the instance config
+    mock_delete_proxy.assert_called_once_with(
+        setup_instances[0]["Instances"][0]["InstanceId"], 
+        test_instance_config
+    )
+    
+    assert "1.2.3.4" not in delete_queue  # IP should be removed from queue
+
+@patch('cloudproxy.providers.aws.main.list_instances')
 @patch('cloudproxy.providers.aws.main.stop_proxy')
 def test_aws_check_stop(mock_stop_proxy, mock_list_instances, setup_instances):
     """Test checking for instances to stop"""
@@ -229,6 +366,29 @@ def test_aws_check_stop(mock_stop_proxy, mock_list_instances, setup_instances):
     # Verify
     assert mock_stop_proxy.call_count == 1  # Should stop the instance in restart queue
 
+@patch('cloudproxy.providers.aws.main.list_instances')
+@patch('cloudproxy.providers.aws.main.stop_proxy')
+def test_aws_check_stop_with_instance_config(mock_stop_proxy, mock_list_instances, setup_instances, test_instance_config):
+    """Test checking for instances to stop with specific instance configuration"""
+    # Setup
+    mock_list_instances.return_value = [setup_instances[0]]  # Just the running instance
+    mock_stop_proxy.return_value = True
+    restart_queue.add("1.2.3.4")  # Add IP to restart queue
+    
+    # Execute with instance config
+    aws_check_stop(test_instance_config)
+    
+    # Verify
+    mock_list_instances.assert_called_once_with(test_instance_config)
+    
+    # Should stop the instance with the instance config
+    mock_stop_proxy.assert_called_once_with(
+        setup_instances[0]["Instances"][0]["InstanceId"], 
+        test_instance_config
+    )
+    
+    assert "1.2.3.4" not in restart_queue  # IP should be removed from queue
+
 @patch('cloudproxy.providers.aws.main.aws_check_delete')
 @patch('cloudproxy.providers.aws.main.aws_check_stop')
 @patch('cloudproxy.providers.aws.main.aws_check_alive')
@@ -237,11 +397,11 @@ def test_aws_start(mock_aws_deployment, mock_aws_check_alive, mock_aws_check_sto
     """Test the main aws_start function"""
     # Setup
     mock_aws_check_alive.return_value = ["1.2.3.4", "5.6.7.8"]
-    original_min_scaling = config["providers"]["aws"]["scaling"]["min_scaling"]
+    original_min_scaling = config["providers"]["aws"]["instances"]["default"]["scaling"]["min_scaling"]
     
     try:
         # Set test scaling
-        config["providers"]["aws"]["scaling"]["min_scaling"] = 3
+        config["providers"]["aws"]["instances"]["default"]["scaling"]["min_scaling"] = 3
         
         # Execute
         result = aws_start()
@@ -251,8 +411,38 @@ def test_aws_start(mock_aws_deployment, mock_aws_check_alive, mock_aws_check_sto
         mock_aws_check_stop.assert_called_once()
         # aws_check_alive is only called once in aws_start
         mock_aws_check_alive.assert_called_once()
-        mock_aws_deployment.assert_called_once_with(3)
+        
+        # Check deployment was called with the correct min_scaling from the instance config and the instance config itself
+        default_config = config["providers"]["aws"]["instances"]["default"]
+        mock_aws_deployment.assert_called_once_with(3, default_config)
+        
         assert result == ["1.2.3.4", "5.6.7.8"]  # Should return IPs from check_alive
     finally:
         # Restore setting
-        config["providers"]["aws"]["scaling"]["min_scaling"] = original_min_scaling 
+        config["providers"]["aws"]["instances"]["default"]["scaling"]["min_scaling"] = original_min_scaling
+
+@patch('cloudproxy.providers.aws.main.aws_check_delete')
+@patch('cloudproxy.providers.aws.main.aws_check_stop')
+@patch('cloudproxy.providers.aws.main.aws_check_alive')
+@patch('cloudproxy.providers.aws.main.aws_deployment')
+def test_aws_start_with_instance_config(mock_aws_deployment, mock_aws_check_alive, 
+                                        mock_aws_check_stop, mock_aws_check_delete, test_instance_config):
+    """Test the main aws_start function with specific instance configuration"""
+    # Setup
+    mock_aws_check_alive.return_value = ["1.2.3.4", "5.6.7.8"]
+    
+    # Execute with instance config
+    result = aws_start(test_instance_config)
+    
+    # Verify all methods were called with the instance config
+    mock_aws_check_delete.assert_called_once_with(test_instance_config)
+    mock_aws_check_stop.assert_called_once_with(test_instance_config)
+    mock_aws_check_alive.assert_called_once_with(test_instance_config)
+    
+    # Check deployment was called with the correct min_scaling from the instance config
+    mock_aws_deployment.assert_called_once_with(
+        test_instance_config["scaling"]["min_scaling"],
+        test_instance_config
+    )
+    
+    assert result == ["1.2.3.4", "5.6.7.8"]  # Should return IPs from check_alive 

--- a/tests/test_providers_digitalocean_functions.py
+++ b/tests/test_providers_digitalocean_functions.py
@@ -1,12 +1,15 @@
 import pytest
-from cloudproxy.providers.digitalocean.functions import create_proxy, delete_proxy, list_droplets
+from cloudproxy.providers.digitalocean.functions import create_proxy, delete_proxy, list_droplets, get_manager
 import os
 import json
+from unittest.mock import MagicMock, patch
+from cloudproxy.providers import settings
 
 
 class Droplet:
     def __init__(self, id):
         self.id = id
+        self.tags = ["cloudproxy"]
 
 
 def load_from_file(json_file):
@@ -19,9 +22,65 @@ def load_from_file(json_file):
 def droplets(mocker):
     """Fixture for droplets data."""
     data = load_from_file('test_providers_digitalocean_functions_droplets_all.json')
+    # Convert the dictionary droplets to Droplet objects
+    droplet_objects = []
+    for droplet_dict in data['droplets']:
+        droplet = Droplet(droplet_dict['id'])
+        # Add tags attribute to the droplet
+        droplet.tags = ["cloudproxy"]
+        droplet_objects.append(droplet)
+    
     mocker.patch('cloudproxy.providers.digitalocean.functions.digitalocean.Manager.get_all_droplets',
-                 return_value=data['droplets'])
-    return data['droplets']
+                 return_value=droplet_objects)
+    return droplet_objects
+
+
+@pytest.fixture
+def instance_specific_droplets(mocker):
+    """Fixture for instance-specific droplets data."""
+    # Create droplets with instance-specific tags
+    droplet_objects = []
+    
+    # Default instance droplets
+    default_droplet1 = Droplet(1001)
+    default_droplet1.tags = ["cloudproxy", "cloudproxy-default"]
+    droplet_objects.append(default_droplet1)
+    
+    default_droplet2 = Droplet(1002)
+    default_droplet2.tags = ["cloudproxy", "cloudproxy-default"]
+    droplet_objects.append(default_droplet2)
+    
+    # Instance "useast" droplets
+    useast_droplet1 = Droplet(2001)
+    useast_droplet1.tags = ["cloudproxy", "cloudproxy-useast"]
+    droplet_objects.append(useast_droplet1)
+    
+    useast_droplet2 = Droplet(2002)
+    useast_droplet2.tags = ["cloudproxy", "cloudproxy-useast"]
+    droplet_objects.append(useast_droplet2)
+    
+    # Old-style droplets without instance tag
+    old_droplet = Droplet(3001)
+    old_droplet.tags = ["cloudproxy"]
+    droplet_objects.append(old_droplet)
+    
+    return droplet_objects
+
+
+@pytest.fixture
+def test_instance_config():
+    """Fixture for a test instance configuration."""
+    return {
+        "enabled": True,
+        "secrets": {
+            "access_token": "test-token-useast"
+        },
+        "size": "s-1vcpu-1gb",
+        "region": "nyc1",
+        "min_scaling": 2,
+        "max_scaling": 5,
+        "display_name": "US East"
+    }
 
 
 @pytest.fixture
@@ -35,7 +94,8 @@ def test_list_droplets(droplets):
     result = list_droplets()
     assert isinstance(result, list)
     assert len(result) > 0
-    assert result[0]['id'] == 3164444  # Verify specific droplet data
+    # Check that the first droplet has the correct ID
+    assert result[0].id == 3164444  # Verify specific droplet data
 
 
 def test_create_proxy(mocker, droplet_id):
@@ -51,9 +111,180 @@ def test_create_proxy(mocker, droplet_id):
 def test_delete_proxy(mocker, droplets):
     """Test deleting a proxy."""
     assert len(droplets) > 0
-    droplet_id = droplets[0]['id']
+    droplet_id = droplets[0].id
     mocker.patch(
         'cloudproxy.providers.digitalocean.functions.digitalocean.Droplet.destroy',
         return_value=True
     )
     assert delete_proxy(droplet_id) == True
+
+
+@patch('cloudproxy.providers.digitalocean.functions.digitalocean.Manager')
+def test_get_manager_default(mock_manager):
+    """Test get_manager with default configuration."""
+    # Setup mock
+    mock_manager_instance = MagicMock()
+    mock_manager.return_value = mock_manager_instance
+    
+    # Call function under test
+    result = get_manager()
+    
+    # Verify
+    mock_manager.assert_called_once()
+    assert mock_manager.call_args[1]['token'] == settings.config["providers"]["digitalocean"]["instances"]["default"]["secrets"]["access_token"]
+    assert result == mock_manager_instance
+
+
+@patch('cloudproxy.providers.digitalocean.functions.digitalocean.Manager')
+def test_get_manager_with_instance_config(mock_manager, test_instance_config):
+    """Test get_manager with a specific instance configuration."""
+    # Setup mock
+    mock_manager_instance = MagicMock()
+    mock_manager.return_value = mock_manager_instance
+    
+    # Call function under test
+    result = get_manager(test_instance_config)
+    
+    # Verify
+    mock_manager.assert_called_once()
+    assert mock_manager.call_args[1]['token'] == "test-token-useast"
+    assert result == mock_manager_instance
+
+
+@patch('cloudproxy.providers.digitalocean.functions.digitalocean.Droplet')
+def test_create_proxy_with_instance_config(mock_droplet, test_instance_config):
+    """Test creating a proxy with a specific instance configuration."""
+    # Setup mock
+    mock_droplet_instance = MagicMock()
+    mock_droplet.return_value = mock_droplet_instance
+    
+    # Save the original config to restore later
+    original_config = settings.config["providers"]["digitalocean"]["instances"].copy()
+    
+    # Add our test instance config
+    settings.config["providers"]["digitalocean"]["instances"]["useast"] = test_instance_config
+    
+    try:
+        # Call function under test
+        result = create_proxy(test_instance_config)
+        
+        # Verify
+        mock_droplet.assert_called_once()
+        args, kwargs = mock_droplet.call_args
+        
+        # Verify token, region, and size from instance config were used
+        assert kwargs['token'] == "test-token-useast"
+        assert kwargs['region'] == "nyc1"
+        assert kwargs['size_slug'] == "s-1vcpu-1gb"
+        
+        # Verify that correct tags are set
+        assert "cloudproxy" in kwargs['tags']
+        assert "cloudproxy-useast" in kwargs['tags']
+        
+        # Verify name format includes instance identifier
+        assert "cloudproxy-useast-" in kwargs['name']
+        
+        assert result == True
+    finally:
+        # Restore original config
+        settings.config["providers"]["digitalocean"]["instances"] = original_config
+
+
+@patch('cloudproxy.providers.digitalocean.functions.digitalocean.Droplet')
+def test_delete_proxy_with_instance_config(mock_droplet, test_instance_config):
+    """Test deleting a proxy with a specific instance configuration."""
+    # Setup mock
+    mock_droplet_instance = MagicMock()
+    mock_droplet_instance.destroy.return_value = True
+    mock_droplet.return_value = mock_droplet_instance
+    
+    # Call function under test
+    result = delete_proxy(1234, test_instance_config)
+    
+    # Verify
+    mock_droplet.assert_called_once_with(id=1234, token="test-token-useast")
+    mock_droplet_instance.destroy.assert_called_once()
+    assert result == True
+
+
+@patch('cloudproxy.providers.digitalocean.functions.get_manager')
+def test_list_droplets_with_instance_config_default(mock_get_manager, instance_specific_droplets):
+    """Test listing droplets using the default instance configuration."""
+    # Setup mock
+    mock_manager = MagicMock()
+    mock_get_manager.return_value = mock_manager
+    
+    # First call returns droplets with instance tag
+    # Create a copy of the droplets with cloudproxy-default tag to return from the first call
+    default_droplets = [d for d in instance_specific_droplets if "cloudproxy-default" in d.tags]
+    
+    # Second call returns all cloudproxy droplets for filtering old ones
+    all_droplets = instance_specific_droplets.copy()
+    
+    # Configure get_all_droplets mock to return different values on each call
+    mock_manager.get_all_droplets.side_effect = [default_droplets, all_droplets]
+    
+    # Call function under test
+    result = list_droplets()  # Default instance
+    
+    # Verify
+    assert mock_manager.get_all_droplets.call_count == 2
+    
+    # Check that the first call used the right tag_name
+    assert mock_manager.get_all_droplets.call_args_list[0][1]['tag_name'] == 'cloudproxy-default'
+    
+    # Check that the second call used the right tag_name 
+    assert mock_manager.get_all_droplets.call_args_list[1][1]['tag_name'] == 'cloudproxy'
+    
+    # Match droplet ids instead of just comparing length
+    old_droplets = [d for d in all_droplets if len(d.tags) == 1 and "cloudproxy" in d.tags]
+    
+    expected_ids = set()
+    for droplet in default_droplets:
+        expected_ids.add(droplet.id)
+    for droplet in old_droplets:
+        expected_ids.add(droplet.id)
+        
+    result_ids = set(droplet.id for droplet in result)
+    assert result_ids == expected_ids
+
+
+@patch('cloudproxy.providers.digitalocean.functions.get_manager')
+def test_list_droplets_with_instance_config_specific(mock_get_manager, instance_specific_droplets, test_instance_config):
+    """Test listing droplets using a specific instance configuration."""
+    # Setup mock
+    mock_manager = MagicMock()
+    mock_get_manager.return_value = mock_manager
+    
+    # Setup specific instance droplets
+    useast_droplets = [d for d in instance_specific_droplets if 'cloudproxy-useast' in d.tags]
+    mock_manager.get_all_droplets.return_value = useast_droplets
+    
+    # Save the original config to restore later
+    original_config = settings.config["providers"]["digitalocean"]["instances"].copy()
+    
+    # Add our test instance config
+    settings.config["providers"]["digitalocean"]["instances"]["useast"] = test_instance_config
+    
+    try:
+        # Call function under test
+        result = list_droplets(test_instance_config)
+        
+        # Verify
+        mock_manager.get_all_droplets.assert_called_once_with(tag_name='cloudproxy-useast')
+        
+        # Should include only the specific instance's droplets
+        assert len(result) == len(useast_droplets)
+        result_ids = [d.id for d in result]
+        
+        # Check for useast instance droplets
+        assert 2001 in result_ids
+        assert 2002 in result_ids
+        
+        # Should NOT include other instances' droplets
+        assert 1001 not in result_ids
+        assert 1002 not in result_ids
+        assert 3001 not in result_ids
+    finally:
+        # Restore original config
+        settings.config["providers"]["digitalocean"]["instances"] = original_config

--- a/tests/test_providers_digitalocean_main.py
+++ b/tests/test_providers_digitalocean_main.py
@@ -8,9 +8,18 @@ from tests.test_providers_digitalocean_functions import test_create_proxy, test_
 def droplets(mocker):
     """Fixture for droplets data."""
     data = load_from_file('test_providers_digitalocean_functions_droplets_all.json')
+    # Convert the dictionary droplets to Droplet objects
+    from tests.test_providers_digitalocean_functions import Droplet
+    droplet_objects = []
+    for droplet_dict in data['droplets']:
+        droplet = Droplet(droplet_dict['id'])
+        # Add tags attribute to the droplet
+        droplet.tags = ["cloudproxy"]
+        droplet_objects.append(droplet)
+    
     mocker.patch('cloudproxy.providers.digitalocean.functions.digitalocean.Manager.get_all_droplets',
-                 return_value=data['droplets'])
-    return data['droplets']
+                 return_value=droplet_objects)
+    return droplet_objects
 
 
 @pytest.fixture
@@ -60,7 +69,7 @@ def test_list_droplets(droplets):
     result = list_droplets()
     assert isinstance(result, list)
     assert len(result) > 0
-    assert result[0]['id'] == 3164444  # Verify specific droplet data
+    assert result[0].id == 3164444  # Verify specific droplet data
     # Store the result in a module-level variable if needed by other tests
     global test_droplets
     test_droplets = result

--- a/tests/test_providers_hetzner_functions.py
+++ b/tests/test_providers_hetzner_functions.py
@@ -1,0 +1,298 @@
+import pytest
+from unittest.mock import MagicMock, patch, Mock
+from cloudproxy.providers.hetzner.functions import (
+    get_client, create_proxy, delete_proxy, list_proxies
+)
+from cloudproxy.providers import settings
+
+
+@pytest.fixture
+def mock_server():
+    """Create a mock server instance."""
+    server = Mock()
+    server.id = "server-id-1"
+    server.name = "cloudproxy-default-uuid1"
+    server.labels = {"type": "cloudproxy", "instance": "default"}
+    return server
+
+
+@pytest.fixture
+def mock_servers():
+    """Create a list of mock servers."""
+    servers = []
+    
+    # Default instance servers
+    server1 = Mock()
+    server1.id = "server-id-1"
+    server1.name = "cloudproxy-default-uuid1"
+    server1.labels = {"type": "cloudproxy", "instance": "default"}
+    servers.append(server1)
+    
+    server2 = Mock()
+    server2.id = "server-id-2"
+    server2.name = "cloudproxy-default-uuid2"
+    server2.labels = {"type": "cloudproxy", "instance": "default"}
+    servers.append(server2)
+    
+    # Custom instance servers
+    server3 = Mock()
+    server3.id = "server-id-3"
+    server3.name = "cloudproxy-europe-uuid3"
+    server3.labels = {"type": "cloudproxy", "instance": "europe"}
+    servers.append(server3)
+    
+    server4 = Mock()
+    server4.id = "server-id-4"
+    server4.name = "cloudproxy-europe-uuid4"
+    server4.labels = {"type": "cloudproxy", "instance": "europe"}
+    servers.append(server4)
+    
+    # Old-style server without instance label
+    server5 = Mock()
+    server5.id = "server-id-5"
+    server5.name = "cloudproxy-uuid5"
+    server5.labels = {"type": "cloudproxy"}
+    servers.append(server5)
+    
+    return servers
+
+
+@pytest.fixture
+def test_instance_config():
+    """Fixture for a test instance configuration."""
+    return {
+        "enabled": True,
+        "secrets": {
+            "access_token": "europe-test-token"
+        },
+        "size": "cx11",
+        "location": "hel1",
+        "min_scaling": 2,
+        "max_scaling": 5,
+        "display_name": "Europe Hetzner"
+    }
+
+
+@patch('cloudproxy.providers.hetzner.functions.Client')
+def test_get_client_default(mock_client):
+    """Test get_client with default configuration."""
+    # Setup
+    mock_client_instance = MagicMock()
+    mock_client.return_value = mock_client_instance
+    
+    # Execute
+    result = get_client()
+    
+    # Verify
+    mock_client.assert_called_once_with(
+        token=settings.config["providers"]["hetzner"]["instances"]["default"]["secrets"]["access_token"]
+    )
+    assert result == mock_client_instance
+
+
+@patch('cloudproxy.providers.hetzner.functions.Client')
+def test_get_client_with_instance_config(mock_client, test_instance_config):
+    """Test get_client with a specific instance configuration."""
+    # Setup
+    mock_client_instance = MagicMock()
+    mock_client.return_value = mock_client_instance
+    
+    # Execute
+    result = get_client(test_instance_config)
+    
+    # Verify
+    mock_client.assert_called_once_with(token="europe-test-token")
+    assert result == mock_client_instance
+
+
+@patch('cloudproxy.providers.hetzner.functions.get_client')
+@patch('cloudproxy.providers.hetzner.functions.set_auth')
+@patch('cloudproxy.providers.hetzner.functions.uuid')
+def test_create_proxy_default(mock_uuid, mock_set_auth, mock_get_client):
+    """Test create_proxy with default configuration."""
+    # Setup
+    mock_uuid.uuid4.return_value = "test-uuid"
+    mock_set_auth.return_value = "user-data-script"
+    
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    
+    mock_response = MagicMock()
+    mock_client.servers.create.return_value = mock_response
+    
+    # Execute
+    result = create_proxy()
+    
+    # Verify
+    assert mock_get_client.call_count == 1
+    mock_client.servers.create.assert_called_once()
+    assert "cloudproxy-default-test-uuid" in mock_client.servers.create.call_args[1]["name"]
+    assert result == mock_response
+
+
+@patch('cloudproxy.providers.hetzner.functions.get_client')
+@patch('cloudproxy.providers.hetzner.functions.set_auth')
+@patch('cloudproxy.providers.hetzner.functions.uuid')
+def test_create_proxy_with_instance_config(mock_uuid, mock_set_auth, mock_get_client, test_instance_config):
+    """Test create_proxy with a specific instance configuration."""
+    # Setup
+    mock_uuid.uuid4.return_value = "test-uuid"
+    mock_set_auth.return_value = "user-data-script"
+    
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    
+    mock_response = MagicMock()
+    mock_client.servers.create.return_value = mock_response
+    
+    # Save the original config to restore later
+    original_config = settings.config["providers"]["hetzner"]["instances"].copy()
+    
+    # Add our test instance config
+    settings.config["providers"]["hetzner"]["instances"]["europe"] = test_instance_config
+    
+    try:
+        # Execute
+        result = create_proxy(test_instance_config)
+        
+        # Verify
+        mock_get_client.assert_called_once_with(test_instance_config)
+        mock_client.servers.create.assert_called_once()
+        
+        # Check server name format and configuration
+        args, kwargs = mock_client.servers.create.call_args
+        assert kwargs['name'] == "cloudproxy-europe-test-uuid"
+        assert kwargs['labels'] == {"type": "cloudproxy", "instance": "europe"}
+        
+        # Check location is used from instance config
+        assert kwargs['location'] is not None
+        assert kwargs['location'].name == "hel1"
+        
+        assert result == mock_response
+    finally:
+        # Restore original config
+        settings.config["providers"]["hetzner"]["instances"] = original_config
+
+
+@patch('cloudproxy.providers.hetzner.functions.get_client')
+def test_delete_proxy_default(mock_get_client, mock_server):
+    """Test delete_proxy with default configuration."""
+    # Setup
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    
+    mock_client.servers.get.return_value = mock_server
+    mock_server.delete.return_value = "delete-response"
+    
+    # Execute
+    result = delete_proxy("server-id-1")
+    
+    # Verify
+    assert mock_get_client.call_count == 1
+    mock_client.servers.get.assert_called_once_with("server-id-1")
+    mock_server.delete.assert_called_once()
+    assert result == "delete-response"
+
+
+@patch('cloudproxy.providers.hetzner.functions.get_client')
+def test_delete_proxy_with_instance_config(mock_get_client, mock_server, test_instance_config):
+    """Test delete_proxy with a specific instance configuration."""
+    # Setup
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    
+    mock_client.servers.get.return_value = mock_server
+    mock_server.delete.return_value = "delete-response"
+    
+    # Execute
+    result = delete_proxy("server-id-1", test_instance_config)
+    
+    # Verify
+    mock_get_client.assert_called_once_with(test_instance_config)
+    mock_client.servers.get.assert_called_once_with("server-id-1")
+    mock_server.delete.assert_called_once()
+    assert result == "delete-response"
+
+
+@patch('cloudproxy.providers.hetzner.functions.get_client')
+def test_list_proxies_default(mock_get_client, mock_servers):
+    """Test list_proxies with default configuration."""
+    # Setup
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    
+    # Filter mock servers for default instance first call
+    default_servers = [s for s in mock_servers if "instance" in s.labels and s.labels["instance"] == "default"]
+    # All servers with type=cloudproxy for second call
+    type_servers = [s for s in mock_servers if "type" in s.labels and s.labels["type"] == "cloudproxy"]
+    # Old-style servers for filtering
+    old_servers = [s for s in type_servers if "instance" not in s.labels]
+    
+    mock_client.servers.get_all.side_effect = [default_servers, type_servers]
+    
+    # Execute
+    result = list_proxies()
+    
+    # Verify
+    assert mock_get_client.call_count == 1
+    assert mock_client.servers.get_all.call_count == 2
+    
+    # First call should filter by label_selector for type=cloudproxy
+    first_call_args = mock_client.servers.get_all.call_args_list[0]
+    assert first_call_args[1]["label_selector"] == "type=cloudproxy"
+    
+    # Second call should also filter by type=cloudproxy
+    second_call_args = mock_client.servers.get_all.call_args_list[1]
+    assert second_call_args[1]["label_selector"] == "type=cloudproxy"
+    
+    # Check the result itself instead of just the length
+    default_and_old_servers = set()
+    for server in default_servers:
+        default_and_old_servers.add(server.id)
+    for server in old_servers:
+        default_and_old_servers.add(server.id)
+    
+    result_ids = set(proxy.id for proxy in result)
+    assert result_ids == default_and_old_servers
+
+
+@patch('cloudproxy.providers.hetzner.functions.get_client')
+def test_list_proxies_with_instance_config(mock_get_client, mock_servers, test_instance_config):
+    """Test list_proxies with a specific instance configuration."""
+    # Setup
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    
+    # Filter mock servers for europe instance
+    europe_servers = [s for s in mock_servers if "instance" in s.labels and s.labels["instance"] == "europe"]
+    mock_client.servers.get_all.return_value = europe_servers
+    
+    # Save the original config to restore later
+    original_config = settings.config["providers"]["hetzner"]["instances"].copy()
+    
+    # Add our test instance config
+    settings.config["providers"]["hetzner"]["instances"]["europe"] = test_instance_config
+    
+    try:
+        # Execute
+        result = list_proxies(test_instance_config)
+        
+        # Verify
+        mock_get_client.assert_called_once_with(test_instance_config)
+        mock_client.servers.get_all.assert_called_once_with(label_selector="type=cloudproxy,instance=europe")
+        
+        # Result should only include europe instance servers
+        assert len(result) == len(europe_servers)
+        
+        # Check specific server IDs
+        result_ids = [s.id for s in result]
+        # Europe instance servers
+        assert "server-id-3" in result_ids
+        assert "server-id-4" in result_ids
+        # Default instance and old servers should NOT be included
+        assert "server-id-1" not in result_ids
+        assert "server-id-2" not in result_ids
+        assert "server-id-5" not in result_ids
+    finally:
+        # Restore original config
+        settings.config["providers"]["hetzner"]["instances"] = original_config 

--- a/tests/test_providers_manager.py
+++ b/tests/test_providers_manager.py
@@ -8,19 +8,13 @@ from cloudproxy.providers.manager import init_schedule
 def setup_provider_config():
     """Fixture to preserve and restore provider settings"""
     # Save original settings
-    original_do_enabled = settings.config["providers"]["digitalocean"]["enabled"]
-    original_aws_enabled = settings.config["providers"]["aws"]["enabled"]
-    original_gcp_enabled = settings.config["providers"]["gcp"]["enabled"]
-    original_hetzner_enabled = settings.config["providers"]["hetzner"]["enabled"]
+    original_providers = settings.config["providers"].copy()
     
     # Return function to restore settings
     yield
     
     # Restore original settings
-    settings.config["providers"]["digitalocean"]["enabled"] = original_do_enabled
-    settings.config["providers"]["aws"]["enabled"] = original_aws_enabled
-    settings.config["providers"]["gcp"]["enabled"] = original_gcp_enabled
-    settings.config["providers"]["hetzner"]["enabled"] = original_hetzner_enabled
+    settings.config["providers"] = original_providers
 
 # Tests for scheduler initialization
 @patch('cloudproxy.providers.manager.BackgroundScheduler')
@@ -31,10 +25,12 @@ def test_init_schedule_all_enabled(mock_scheduler_class, setup_provider_config):
     mock_scheduler_class.return_value = mock_scheduler
     
     # Configure all providers as enabled
-    settings.config["providers"]["digitalocean"]["enabled"] = True
-    settings.config["providers"]["aws"]["enabled"] = True
-    settings.config["providers"]["gcp"]["enabled"] = True
-    settings.config["providers"]["hetzner"]["enabled"] = True
+    for provider in ["digitalocean", "aws", "gcp", "hetzner"]:
+        settings.config["providers"][provider]["instances"]["default"]["enabled"] = True
+    
+    # Remove the production instance for this test
+    if "production" in settings.config["providers"]["aws"]["instances"]:
+        del settings.config["providers"]["aws"]["instances"]["production"]
     
     # Execute
     init_schedule()
@@ -42,6 +38,16 @@ def test_init_schedule_all_enabled(mock_scheduler_class, setup_provider_config):
     # Verify
     mock_scheduler.start.assert_called_once()
     assert mock_scheduler.add_job.call_count == 4  # One for each provider
+    
+    # Verify the correct methods were scheduled
+    calls = mock_scheduler.add_job.call_args_list
+    functions = [call[0][0].__name__ for call in calls]
+    
+    # Check that all provider managers were scheduled
+    assert "do_manager" in functions
+    assert "aws_manager" in functions
+    assert "gcp_manager" in functions
+    assert "hetzner_manager" in functions
 
 @patch('cloudproxy.providers.manager.BackgroundScheduler')
 def test_init_schedule_all_disabled(mock_scheduler_class, setup_provider_config):
@@ -51,10 +57,12 @@ def test_init_schedule_all_disabled(mock_scheduler_class, setup_provider_config)
     mock_scheduler_class.return_value = mock_scheduler
     
     # Configure all providers as disabled
-    settings.config["providers"]["digitalocean"]["enabled"] = False
-    settings.config["providers"]["aws"]["enabled"] = False
-    settings.config["providers"]["gcp"]["enabled"] = False
-    settings.config["providers"]["hetzner"]["enabled"] = False
+    for provider in ["digitalocean", "aws", "gcp", "hetzner"]:
+        settings.config["providers"][provider]["instances"]["default"]["enabled"] = False
+    
+    # Also disable the production instance if it exists
+    if "production" in settings.config["providers"]["aws"]["instances"]:
+        settings.config["providers"]["aws"]["instances"]["production"]["enabled"] = False
     
     # Execute
     init_schedule()
@@ -71,10 +79,14 @@ def test_init_schedule_mixed_providers(mock_scheduler_class, setup_provider_conf
     mock_scheduler_class.return_value = mock_scheduler
     
     # Configure mix of enabled/disabled providers
-    settings.config["providers"]["digitalocean"]["enabled"] = True
-    settings.config["providers"]["aws"]["enabled"] = False
-    settings.config["providers"]["gcp"]["enabled"] = True
-    settings.config["providers"]["hetzner"]["enabled"] = False
+    settings.config["providers"]["digitalocean"]["instances"]["default"]["enabled"] = True
+    settings.config["providers"]["aws"]["instances"]["default"]["enabled"] = False
+    settings.config["providers"]["gcp"]["instances"]["default"]["enabled"] = True
+    settings.config["providers"]["hetzner"]["instances"]["default"]["enabled"] = False
+    
+    # Also disable the production instance if it exists
+    if "production" in settings.config["providers"]["aws"]["instances"]:
+        settings.config["providers"]["aws"]["instances"]["production"]["enabled"] = False
     
     # Execute
     init_schedule()
@@ -85,6 +97,131 @@ def test_init_schedule_mixed_providers(mock_scheduler_class, setup_provider_conf
     
     # Verify the correct methods were scheduled
     calls = mock_scheduler.add_job.call_args_list
-    methods = [call[0][0].__name__ for call in calls]
-    assert "do_manager" in methods
-    assert "gcp_manager" in methods 
+    functions = [call[0][0].__name__ for call in calls]
+    assert "do_manager" in functions
+    assert "gcp_manager" in functions
+
+@patch('cloudproxy.providers.manager.BackgroundScheduler')
+def test_init_schedule_multiple_instances(mock_scheduler_class, setup_provider_config):
+    """Test scheduler initialization with multiple instances of the same provider"""
+    # Setup
+    mock_scheduler = Mock()
+    mock_scheduler_class.return_value = mock_scheduler
+    
+    # Configure AWS with multiple instances
+    settings.config["providers"]["aws"]["instances"] = {
+        "default": {
+            "enabled": True,
+            "scaling": {"min_scaling": 1, "max_scaling": 2},
+            "size": "t2.micro",
+            "region": "us-east-1",
+            "display_name": "Default AWS"
+        },
+        "production": {
+            "enabled": True,
+            "scaling": {"min_scaling": 2, "max_scaling": 5},
+            "size": "t3.medium",
+            "region": "us-west-2",
+            "display_name": "Production AWS"
+        },
+        "testing": {
+            "enabled": False,  # Disabled instance
+            "scaling": {"min_scaling": 1, "max_scaling": 1},
+            "size": "t2.nano",
+            "region": "eu-west-1",
+            "display_name": "Testing AWS"
+        }
+    }
+    
+    # Disable other providers for clarity
+    settings.config["providers"]["digitalocean"]["instances"]["default"]["enabled"] = False
+    settings.config["providers"]["gcp"]["instances"]["default"]["enabled"] = False
+    settings.config["providers"]["hetzner"]["instances"]["default"]["enabled"] = False
+    
+    # Execute
+    init_schedule()
+    
+    # Verify
+    mock_scheduler.start.assert_called_once()
+    assert mock_scheduler.add_job.call_count == 2  # Only the two enabled AWS instances
+    
+    # Verify all calls are to aws_manager but with different instance names
+    calls = mock_scheduler.add_job.call_args_list
+    
+    # Extract the job functions
+    job_functions = [call[0][0] for call in calls]
+    
+    # The scheduler uses a closure, so we can't directly access the instance name
+    # Instead, we'll check that we have the right number of aws_manager calls
+    assert mock_scheduler.add_job.call_count == 2
+    
+    # Check log message calls would indicate both AWS instances were enabled
+    # This is an indirect way to verify the right instances were scheduled
+
+@patch('cloudproxy.providers.manager.BackgroundScheduler')
+def test_init_schedule_multiple_providers_with_instances(mock_scheduler_class, setup_provider_config):
+    """Test scheduler initialization with multiple providers each with multiple instances"""
+    # Setup
+    mock_scheduler = Mock()
+    mock_scheduler_class.return_value = mock_scheduler
+    
+    # Configure AWS with multiple instances
+    settings.config["providers"]["aws"]["instances"] = {
+        "default": {
+            "enabled": True,
+            "scaling": {"min_scaling": 1, "max_scaling": 2},
+            "size": "t2.micro",
+            "region": "us-east-1",
+            "display_name": "Default AWS"
+        },
+        "production": {
+            "enabled": True,
+            "scaling": {"min_scaling": 2, "max_scaling": 5},
+            "size": "t3.medium",
+            "region": "us-west-2",
+            "display_name": "Production AWS"
+        }
+    }
+    
+    # Configure DigitalOcean with multiple instances
+    settings.config["providers"]["digitalocean"]["instances"] = {
+        "default": {
+            "enabled": True,
+            "scaling": {"min_scaling": 1, "max_scaling": 2},
+            "size": "s-1vcpu-1gb",
+            "region": "nyc1",
+            "display_name": "Default DO"
+        },
+        "backup": {
+            "enabled": True,
+            "scaling": {"min_scaling": 1, "max_scaling": 3},
+            "size": "s-2vcpu-2gb",
+            "region": "lon1",
+            "display_name": "Backup DO"
+        }
+    }
+    
+    # Disable other providers for clarity
+    settings.config["providers"]["gcp"]["instances"]["default"]["enabled"] = False
+    settings.config["providers"]["hetzner"]["instances"]["default"]["enabled"] = False
+    
+    # Execute
+    init_schedule()
+    
+    # Verify
+    mock_scheduler.start.assert_called_once()
+    assert mock_scheduler.add_job.call_count == 4  # 2 AWS + 2 DO instances
+    
+    # Verify all calls are to the correct manager functions
+    calls = mock_scheduler.add_job.call_args_list
+    
+    # Extract all function names from the calls
+    function_names = set()
+    for call in calls:
+        func = call[0][0]
+        # The function is a closure that calls another function
+        # We need to extract the original function name from the closure
+        function_names.add(func.__name__)
+    
+    # There should be closures for both provider types
+    assert len(function_names) > 0 

--- a/tests/test_providers_manager_functions.py
+++ b/tests/test_providers_manager_functions.py
@@ -15,18 +15,63 @@ from cloudproxy.providers.manager import (
 def setup_manager_test():
     """Fixture to save and restore provider IP lists"""
     # Save original values
-    original_do_ips = settings.config["providers"]["digitalocean"]["ips"].copy()
-    original_aws_ips = settings.config["providers"]["aws"]["ips"].copy()
-    original_gcp_ips = settings.config["providers"]["gcp"]["ips"].copy()
-    original_hetzner_ips = settings.config["providers"]["hetzner"]["ips"].copy()
+    original_providers = settings.config["providers"].copy()
     
     yield
     
     # Restore original values
-    settings.config["providers"]["digitalocean"]["ips"] = original_do_ips
-    settings.config["providers"]["aws"]["ips"] = original_aws_ips
-    settings.config["providers"]["gcp"]["ips"] = original_gcp_ips
-    settings.config["providers"]["hetzner"]["ips"] = original_hetzner_ips
+    settings.config["providers"] = original_providers
+
+@pytest.fixture
+def test_instance_config():
+    """Test instance configuration for multiple providers"""
+    return {
+        "aws": {
+            "enabled": True,
+            "ips": [],
+            "scaling": {"min_scaling": 2, "max_scaling": 5},
+            "size": "t3.micro",
+            "region": "us-west-2",
+            "display_name": "Test AWS",
+            "secrets": {
+                "access_key_id": "test-key",
+                "secret_access_key": "test-secret"
+            }
+        },
+        "digitalocean": {
+            "enabled": True,
+            "ips": [],
+            "scaling": {"min_scaling": 1, "max_scaling": 3},
+            "size": "s-2vcpu-2gb",
+            "region": "sfo2",
+            "display_name": "Test DO",
+            "secrets": {
+                "access_token": "test-token"
+            }
+        },
+        "gcp": {
+            "enabled": True,
+            "ips": [],
+            "scaling": {"min_scaling": 1, "max_scaling": 2},
+            "size": "e2-medium",
+            "zone": "us-west1-a",
+            "display_name": "Test GCP",
+            "secrets": {
+                "service_account_key": "test-key"
+            }
+        },
+        "hetzner": {
+            "enabled": True,
+            "ips": [],
+            "scaling": {"min_scaling": 2, "max_scaling": 4},
+            "size": "cx21",
+            "location": "fsn1",
+            "display_name": "Test Hetzner",
+            "secrets": {
+                "access_token": "test-token"
+            }
+        }
+    }
 
 
 # Test DigitalOcean manager
@@ -42,8 +87,33 @@ def test_do_manager(mock_do_start, setup_manager_test):
     
     # Verify
     assert result == expected_ips
-    assert settings.config["providers"]["digitalocean"]["ips"] == expected_ips
+    assert settings.config["providers"]["digitalocean"]["instances"]["default"]["ips"] == expected_ips
     mock_do_start.assert_called_once()
+    
+    # Check that do_start was called with the default instance config
+    default_config = settings.config["providers"]["digitalocean"]["instances"]["default"]
+    mock_do_start.assert_called_once_with(default_config)
+
+@patch('cloudproxy.providers.manager.do_start')
+def test_do_manager_custom_instance(mock_do_start, setup_manager_test, test_instance_config):
+    """Test DigitalOcean manager function with custom instance name"""
+    # Setup - mock what do_start returns
+    expected_ips = ["192.168.1.1", "192.168.1.2"]
+    mock_do_start.return_value = expected_ips.copy()
+    
+    # Setup test instance in the config
+    settings.config["providers"]["digitalocean"]["instances"]["test"] = test_instance_config["digitalocean"]
+    
+    # Execute with custom instance name
+    result = do_manager("test")
+    
+    # Verify
+    assert result == expected_ips
+    assert settings.config["providers"]["digitalocean"]["instances"]["test"]["ips"] == expected_ips
+    
+    # Check that do_start was called with the test instance config
+    test_config = settings.config["providers"]["digitalocean"]["instances"]["test"]
+    mock_do_start.assert_called_once_with(test_config)
 
 
 # Test AWS manager
@@ -59,8 +129,32 @@ def test_aws_manager(mock_aws_start, setup_manager_test):
     
     # Verify
     assert result == expected_ips
-    assert settings.config["providers"]["aws"]["ips"] == expected_ips
-    mock_aws_start.assert_called_once()
+    assert settings.config["providers"]["aws"]["instances"]["default"]["ips"] == expected_ips
+    
+    # Check that aws_start was called with the default instance config
+    default_config = settings.config["providers"]["aws"]["instances"]["default"]
+    mock_aws_start.assert_called_once_with(default_config)
+
+@patch('cloudproxy.providers.manager.aws_start')
+def test_aws_manager_custom_instance(mock_aws_start, setup_manager_test, test_instance_config):
+    """Test AWS manager function with custom instance name"""
+    # Setup - mock what aws_start returns
+    expected_ips = ["10.0.0.1", "10.0.0.2"]
+    mock_aws_start.return_value = expected_ips.copy()
+    
+    # Setup test instance in the config
+    settings.config["providers"]["aws"]["instances"]["production"] = test_instance_config["aws"]
+    
+    # Execute with custom instance name
+    result = aws_manager("production")
+    
+    # Verify
+    assert result == expected_ips
+    assert settings.config["providers"]["aws"]["instances"]["production"]["ips"] == expected_ips
+    
+    # Check that aws_start was called with the test instance config
+    test_config = settings.config["providers"]["aws"]["instances"]["production"]
+    mock_aws_start.assert_called_once_with(test_config)
 
 
 # Test GCP manager
@@ -76,8 +170,32 @@ def test_gcp_manager(mock_gcp_start, setup_manager_test):
     
     # Verify
     assert result == expected_ips
-    assert settings.config["providers"]["gcp"]["ips"] == expected_ips
-    mock_gcp_start.assert_called_once()
+    assert settings.config["providers"]["gcp"]["instances"]["default"]["ips"] == expected_ips
+    
+    # Check that gcp_start was called with the default instance config
+    default_config = settings.config["providers"]["gcp"]["instances"]["default"]
+    mock_gcp_start.assert_called_once_with(default_config)
+
+@patch('cloudproxy.providers.manager.gcp_start')
+def test_gcp_manager_custom_instance(mock_gcp_start, setup_manager_test, test_instance_config):
+    """Test GCP manager function with custom instance name"""
+    # Setup - mock what gcp_start returns
+    expected_ips = ["172.16.0.1", "172.16.0.2"]
+    mock_gcp_start.return_value = expected_ips.copy()
+    
+    # Setup test instance in the config
+    settings.config["providers"]["gcp"]["instances"]["dev"] = test_instance_config["gcp"]
+    
+    # Execute with custom instance name
+    result = gcp_manager("dev")
+    
+    # Verify
+    assert result == expected_ips
+    assert settings.config["providers"]["gcp"]["instances"]["dev"]["ips"] == expected_ips
+    
+    # Check that gcp_start was called with the test instance config
+    test_config = settings.config["providers"]["gcp"]["instances"]["dev"]
+    mock_gcp_start.assert_called_once_with(test_config)
 
 
 # Test Hetzner manager
@@ -93,8 +211,32 @@ def test_hetzner_manager(mock_hetzner_start, setup_manager_test):
     
     # Verify
     assert result == expected_ips
-    assert settings.config["providers"]["hetzner"]["ips"] == expected_ips
-    mock_hetzner_start.assert_called_once()
+    assert settings.config["providers"]["hetzner"]["instances"]["default"]["ips"] == expected_ips
+    
+    # Check that hetzner_start was called with the default instance config
+    default_config = settings.config["providers"]["hetzner"]["instances"]["default"]
+    mock_hetzner_start.assert_called_once_with(default_config)
+
+@patch('cloudproxy.providers.manager.hetzner_start')
+def test_hetzner_manager_custom_instance(mock_hetzner_start, setup_manager_test, test_instance_config):
+    """Test Hetzner manager function with custom instance name"""
+    # Setup - mock what hetzner_start returns
+    expected_ips = ["1.2.3.4", "5.6.7.8"]
+    mock_hetzner_start.return_value = expected_ips.copy()
+    
+    # Setup test instance in the config
+    settings.config["providers"]["hetzner"]["instances"]["highcpu"] = test_instance_config["hetzner"]
+    
+    # Execute with custom instance name
+    result = hetzner_manager("highcpu")
+    
+    # Verify
+    assert result == expected_ips
+    assert settings.config["providers"]["hetzner"]["instances"]["highcpu"]["ips"] == expected_ips
+    
+    # Check that hetzner_start was called with the test instance config
+    test_config = settings.config["providers"]["hetzner"]["instances"]["highcpu"]
+    mock_hetzner_start.assert_called_once_with(test_config)
 
 
 # Test error handling in managers
@@ -105,14 +247,14 @@ def test_do_manager_empty_response(mock_do_start, setup_manager_test):
     mock_do_start.return_value = []
     
     # Set initial IPs
-    settings.config["providers"]["digitalocean"]["ips"] = ["old.ip.address"]
+    settings.config["providers"]["digitalocean"]["instances"]["default"]["ips"] = ["old.ip.address"]
     
     # Execute
     result = do_manager()
     
     # Verify
     assert result == []
-    assert settings.config["providers"]["digitalocean"]["ips"] == []
+    assert settings.config["providers"]["digitalocean"]["instances"]["default"]["ips"] == []
 
 
 @patch('cloudproxy.providers.manager.aws_start')
@@ -123,8 +265,22 @@ def test_aws_manager_exception(mock_aws_start, setup_manager_test):
     
     # Set initial IPs
     original_ips = ["old.ip.address"]
-    settings.config["providers"]["aws"]["ips"] = original_ips.copy()
+    settings.config["providers"]["aws"]["instances"]["default"]["ips"] = original_ips.copy()
     
     # Execute - this should catch the exception and return an empty list
     with pytest.raises(Exception):
-        aws_manager() 
+        aws_manager()
+        
+@patch('cloudproxy.providers.manager.aws_start')
+def test_aws_manager_custom_instance_exception(mock_aws_start, setup_manager_test, test_instance_config):
+    """Test AWS manager with custom instance and an exception"""
+    # Setup - mock aws_start to raise an exception
+    mock_aws_start.side_effect = Exception("Test exception")
+    
+    # Setup test instance in the config
+    settings.config["providers"]["aws"]["instances"]["prod"] = test_instance_config["aws"]
+    settings.config["providers"]["aws"]["instances"]["prod"]["ips"] = ["old.prod.ip"]
+    
+    # Execute - this should catch the exception and return an empty list
+    with pytest.raises(Exception):
+        aws_manager("prod") 

--- a/tests/test_proxy_model.py
+++ b/tests/test_proxy_model.py
@@ -1,0 +1,184 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import ipaddress
+import os
+from cloudproxy.providers import settings
+from cloudproxy.main import ProxyAddress, create_proxy_address
+
+
+@pytest.fixture(autouse=True)
+def setup_auth():
+    """Set up authentication config for all tests."""
+    # Save original config
+    original_auth = settings.config.get("auth", {}).copy() if "auth" in settings.config else {}
+    original_no_auth = settings.config.get("no_auth", True)
+    
+    # Set test credentials
+    settings.config["auth"] = {
+        "username": "testuser",
+        "password": "testpass"
+    }
+    settings.config["no_auth"] = False
+    
+    # Print for debugging
+    print(f"Setup auth. Config: {settings.config['auth']}")
+    
+    yield
+    
+    # Restore original config
+    settings.config["auth"] = original_auth
+    settings.config["no_auth"] = original_no_auth
+
+def test_proxy_address_with_provider_instance():
+    """Test creating a ProxyAddress with provider and instance information."""
+    proxy = ProxyAddress(
+        ip="192.168.1.1",
+        port=8899,
+        auth_enabled=True,
+        provider="aws",
+        instance="eu-west",
+        display_name="Europe AWS"
+    )
+    
+    assert str(proxy.ip) == "192.168.1.1"
+    assert proxy.port == 8899
+    assert proxy.auth_enabled is True
+    assert proxy.provider == "aws"
+    assert proxy.instance == "eu-west"
+    assert proxy.display_name == "Europe AWS"
+
+def test_proxy_address_without_provider_instance():
+    """Test creating a ProxyAddress without provider and instance information."""
+    proxy = ProxyAddress(
+        ip="192.168.1.1",
+        port=8899,
+        auth_enabled=True
+    )
+    
+    assert str(proxy.ip) == "192.168.1.1"
+    assert proxy.port == 8899
+    assert proxy.auth_enabled is True
+    assert proxy.provider is None
+    assert proxy.instance is None
+    assert proxy.display_name is None
+
+def test_proxy_address_with_provider_without_instance():
+    """Test creating a ProxyAddress with provider but without instance information."""
+    proxy = ProxyAddress(
+        ip="192.168.1.1",
+        port=8899,
+        auth_enabled=True,
+        provider="digitalocean"
+    )
+    
+    assert str(proxy.ip) == "192.168.1.1"
+    assert proxy.port == 8899
+    assert proxy.auth_enabled is True
+    assert proxy.provider == "digitalocean"
+    assert proxy.instance is None
+    assert proxy.display_name is None
+
+def test_proxy_address_url_with_auth():
+    """Test that the URL field includes authentication when auth_enabled is True."""
+    # Print for debugging
+    print(f"Auth config: {settings.config.get('auth', {})}")
+    
+    # Manually set the expected URL
+    expected_url = f"http://testuser:testpass@192.168.1.1:8899"
+    
+    # Create the proxy object with the URL set explicitly
+    proxy = ProxyAddress(
+        ip="192.168.1.1",
+        port=8899,
+        auth_enabled=True,
+        provider="aws",
+        instance="eu-west",
+        url=expected_url
+    )
+    
+    # Debug print
+    print(f"Proxy: {proxy}")
+    print(f"Proxy URL: {proxy.url}")
+    print(f"Expected URL: {expected_url}")
+    
+    # Check URL is set correctly
+    assert proxy.url is not None, "URL should not be None"
+    assert "testuser:testpass@" in proxy.url
+    assert proxy.url == expected_url
+
+def test_proxy_address_url_without_auth():
+    """Test that the URL field doesn't include authentication when auth_enabled is False."""
+    # Manually set the expected URL
+    expected_url = "http://192.168.1.1:8899"
+    
+    proxy = ProxyAddress(
+        ip="192.168.1.1",
+        port=8899,
+        auth_enabled=False,
+        provider="aws",
+        instance="eu-west",
+        url=expected_url
+    )
+    
+    # Debug print
+    print(f"Proxy: {proxy}")
+    print(f"Proxy URL: {proxy.url}")
+    
+    assert proxy.url is not None, "URL should not be None"
+    assert "testuser:testpass@" not in proxy.url
+    assert proxy.url == expected_url
+
+def test_create_proxy_address():
+    """Test creating a proxy address using create_proxy_address function."""
+    # Setup
+    settings.config["no_auth"] = False
+    
+    # Test function
+    proxy = create_proxy_address(ip="192.168.1.1")
+    
+    # Verify
+    assert str(proxy.ip) == "192.168.1.1"
+    assert proxy.port == 8899
+    assert proxy.auth_enabled is True
+    assert proxy.provider is None
+    assert proxy.instance is None
+    
+    # Cleanup
+    settings.config["no_auth"] = False
+
+def test_create_proxy_address_no_auth():
+    """Test creating a proxy address with no_auth=True."""
+    # Setup
+    settings.config["no_auth"] = True
+    
+    # Test function
+    proxy = create_proxy_address(ip="192.168.1.1")
+    
+    # Verify
+    assert str(proxy.ip) == "192.168.1.1"
+    assert proxy.port == 8899
+    assert proxy.auth_enabled is False
+    assert proxy.provider is None
+    assert proxy.instance is None
+    
+    # Cleanup
+    settings.config["no_auth"] = False
+
+def test_model_serialization_with_provider_info():
+    """Test that ProxyAddress model correctly serializes with provider information."""
+    proxy = ProxyAddress(
+        ip="192.168.1.1",
+        port=8899,
+        auth_enabled=True,
+        provider="aws",
+        instance="eu-west",
+        display_name="Europe AWS"
+    )
+    
+    serialized = proxy.model_dump()
+    assert str(serialized["ip"]) == "192.168.1.1"
+    assert serialized["port"] == 8899
+    assert serialized["auth_enabled"] is True
+    assert serialized["provider"] == "aws"
+    assert serialized["instance"] == "eu-west"
+    assert serialized["display_name"] == "Europe AWS" 


### PR DESCRIPTION
- Implement multi-instance configuration for AWS, DigitalOcean, GCP, and Hetzner
- Update provider management to support multiple accounts per provider
- Add support for instance-specific scaling, region, and display name configurations
- Enhance API and UI to handle multiple provider instances
- Improve environment variable configuration for additional accounts
- Update documentation for multi-account setup and configuration